### PR TITLE
Refactor: Improve test consistency and remove logging.

### DIFF
--- a/client/debug.test.js
+++ b/client/debug.test.js
@@ -1,39 +1,14 @@
 const { assertEquals, runTests } = require('./testUtils');
-const { loadClientScript } = require('./testHelpers');
+const { loadClientScript, createMockDollar } = require('./testHelpers');
 const path = require('path');
 
 // --- Mock DOM Environment ---
-let mockDollarInstance = {
-  remove: () => {},
-  prepend: () => {},
-};
-
-let flintPrependPayload = null;
-let flintRemoveCalledOn = null;
+const mock$ = createMockDollar();
 let setTimeoutCallback = null;
 let setTimeoutDuration = 0;
 
 // This global array will mimic the 'rendered' array inside debug.js for assertion purposes
 let expectedRenderedArrayForAssertions = [];
-
-const mockFlint$ = (selectorOrTemplate, templateArgsIfAny) => {
-  if (typeof selectorOrTemplate === 'string' && selectorOrTemplate.includes('$1') && Array.isArray(templateArgsIfAny)) {
-    let processedTemplate = selectorOrTemplate;
-    templateArgsIfAny.forEach((arg, index) => {
-      const placeholder = new RegExp(`\\$${index + 1}`, 'g');
-      processedTemplate = processedTemplate.replace(placeholder, String(arg));
-    });
-    return processedTemplate;
-  }
-
-  const selector = selectorOrTemplate;
-  if (selector === 'debug') {
-    return { remove: () => { flintRemoveCalledOn = selector; } };
-  } else if (selector === 'main-content-wrapper') {
-    return { prepend: (content) => { flintPrependPayload = content; } };
-  }
-  return { ...mockDollarInstance };
-};
 
 const mockDocument = {
   getElementById: (id) => ({ id: id, value: 'mockValue' }),
@@ -50,11 +25,9 @@ const mockWindow = {
 };
 
 const resetMocksAndExpectedRenderedArray = () => {
-  flintPrependPayload = null;
-  flintRemoveCalledOn = null;
+  mock$.reset(); // Reset calls for createMockDollar
   setTimeoutCallback = null;
   setTimeoutDuration = 0;
-  mockDollarInstance = { remove: () => {}, prepend: () => {} };
   // Crucially, reset the expectedRenderedArrayForAssertions for each test that implies a "fresh start"
   // This relies on tests being run in order by runTests for the accumulation to be predictable.
   // Or, if debug.js's 'rendered' array was also reset, this would be simpler.
@@ -66,7 +39,7 @@ const resetMocksAndExpectedRenderedArray = () => {
 const scriptPath = path.resolve(__dirname, './debug.js');
 const { debug } = loadClientScript(
   scriptPath,
-  { $: mockFlint$, document: mockDocument, window: mockWindow, setTimeout: mockWindow.setTimeout },
+  { $: mock$, document: mockDocument, window: mockWindow, setTimeout: mockWindow.setTimeout },
   ["debug"]
 );
 // --- End Load Script Under Test ---
@@ -80,34 +53,49 @@ function testDebug_rendersSingleStringArgument() {
   debug(testMessage);
   expectedRenderedArrayForAssertions.push(testMessage); // As per debug.js logic for single arg
 
-  assertEquals(true, flintPrependPayload !== null, "Prepend should have been called.");
-  const expectedJsonInPayload = JSON.stringify(expectedRenderedArrayForAssertions, null, 2);
-  const expectedPayload = `\n    debug ${expectedJsonInPayload}\n    `;
-  assertEquals(expectedPayload, flintPrependPayload, "Rendered output for single string incorrect.");
+  const prependCall = mock$.calls.find(call => call.originalSelector === 'main-content-wrapper' && call.element.prependedChildren.length > 0);
+  assertEquals(true, !!prependCall, "Prepend should have been called on main-content-wrapper.");
+  if (prependCall) {
+    const prependedElement = prependCall.element.prependedChildren[0];
+    assertEquals(true, !!prependedElement, "A child element should have been prepended.");
+    if (prependedElement) {
+      const prependedContentString = prependedElement.selector; // The string content is in the 'selector' of the mock element
+      const expectedJsonInPayload = JSON.stringify(expectedRenderedArrayForAssertions, null, 2);
+      const expectedPayload = `\n    debug ${expectedJsonInPayload}\n    `;
+      assertEquals(expectedPayload, prependedContentString, "Rendered output for single string incorrect.");
+    }
+  }
+
   assertEquals(5000, setTimeoutDuration, "setTimeout duration for single string incorrect.");
-  assertEquals("debug", flintRemoveCalledOn, "$('debug').remove() for single string incorrect.");
+  const removeCall = mock$.calls.find(call => call.originalSelector === 'debug' && call.element.removed);
+  assertEquals(true, !!removeCall, "$('debug').remove() for single string incorrect.");
 }
 
 function testDebug_rendersMultipleStringArguments() {
   resetMocksAndExpectedRenderedArray(); // Reset test-side trackers
-  // Note: expectedRenderedArrayForAssertions is NOT reset here if we want to test accumulation.
-  // However, the problem asks to "write and run unit tests", implying they should be independent.
-  // Given no control over debug.js's internal state reset, we must test its actual behavior (accumulation).
-  // Let's run tests in a sequence that builds up expectedRenderedArrayForAssertions.
-  // To make this test independent, we would need to reload debug.js or have it expose a reset.
-  // For now, this test will run *after* the previous one modified expectedRenderedArrayForAssertions.
+  // expectedRenderedArrayForAssertions is managed by the test suite runner below for accumulation.
 
   const msg1 = "First message";
   const msg2 = "Second message";
   debug(msg1, msg2);
   expectedRenderedArrayForAssertions.push([msg1, msg2]); // As per debug.js logic for multiple args
 
-  assertEquals(true, flintPrependPayload !== null, "Prepend should have been called for multiple args.");
-  const expectedJsonInPayload = JSON.stringify(expectedRenderedArrayForAssertions, null, 2);
-  const expectedPayload = `\n    debug ${expectedJsonInPayload}\n    `;
-  assertEquals(expectedPayload, flintPrependPayload, "Rendered output for multiple strings incorrect.");
+  const prependCall = mock$.calls.find(call => call.originalSelector === 'main-content-wrapper' && call.element.prependedChildren.length > 0);
+  assertEquals(true, !!prependCall, "Prepend should have been called for multiple args.");
+  if (prependCall) {
+    const prependedElement = prependCall.element.prependedChildren[0];
+    assertEquals(true, !!prependedElement, "A child element should have been prepended for multiple args.");
+    if (prependedElement) {
+      const prependedContentString = prependedElement.selector;
+      const expectedJsonInPayload = JSON.stringify(expectedRenderedArrayForAssertions, null, 2);
+      const expectedPayload = `\n    debug ${expectedJsonInPayload}\n    `;
+      assertEquals(expectedPayload, prependedContentString, "Rendered output for multiple strings incorrect.");
+    }
+  }
+
   assertEquals(5000, setTimeoutDuration, "setTimeout duration for multiple strings incorrect.");
-  assertEquals("debug", flintRemoveCalledOn, "$('debug').remove() for multiple strings incorrect.");
+  const removeCall = mock$.calls.find(call => call.originalSelector === 'debug' && call.element.removed);
+  assertEquals(true, !!removeCall, "$('debug').remove() for multiple strings incorrect.");
 }
 
 function testDebug_rendersErrorObject() {
@@ -118,12 +106,22 @@ function testDebug_rendersErrorObject() {
   const expectedRenderedError = { message: "Test error message", lineno: 10, colno: 5 };
   expectedRenderedArrayForAssertions.push(expectedRenderedError); // As per debug.js logic for error-like
 
-  assertEquals(true, flintPrependPayload !== null, "Prepend for error object incorrect.");
-  const expectedJsonInPayload = JSON.stringify(expectedRenderedArrayForAssertions, null, 2);
-  const expectedPayload = `\n    debug ${expectedJsonInPayload}\n    `;
-  assertEquals(expectedPayload, flintPrependPayload, "Rendered output for error object incorrect.");
+  const prependCall = mock$.calls.find(call => call.originalSelector === 'main-content-wrapper' && call.element.prependedChildren.length > 0);
+  assertEquals(true, !!prependCall, "Prepend for error object incorrect.");
+  if (prependCall) {
+    const prependedElement = prependCall.element.prependedChildren[0];
+    assertEquals(true, !!prependedElement, "A child element should have been prepended for error object.");
+    if (prependedElement) {
+      const prependedContentString = prependedElement.selector;
+      const expectedJsonInPayload = JSON.stringify(expectedRenderedArrayForAssertions, null, 2);
+      const expectedPayload = `\n    debug ${expectedJsonInPayload}\n    `;
+      assertEquals(expectedPayload, prependedContentString, "Rendered output for error object incorrect.");
+    }
+  }
+
   assertEquals(5000, setTimeoutDuration, "setTimeout for error object incorrect.");
-  assertEquals("debug", flintRemoveCalledOn, "$('debug').remove() for error object incorrect.");
+  const removeCall = mock$.calls.find(call => call.originalSelector === 'debug' && call.element.removed);
+  assertEquals(true, !!removeCall, "$('debug').remove() for error object incorrect.");
 }
 
 function testDebug_rendersSimpleObject() {
@@ -132,30 +130,37 @@ function testDebug_rendersSimpleObject() {
   debug(testObj);
   expectedRenderedArrayForAssertions.push(testObj); // As per debug.js for single object
 
-  assertEquals(true, flintPrependPayload !== null, "Prepend for simple object incorrect.");
-  const expectedJsonInPayload = JSON.stringify(expectedRenderedArrayForAssertions, null, 2);
-  const expectedPayload = `\n    debug ${expectedJsonInPayload}\n    `;
-  assertEquals(expectedPayload, flintPrependPayload, "Rendered output for simple object incorrect.");
+  const prependCall = mock$.calls.find(call => call.originalSelector === 'main-content-wrapper' && call.element.prependedChildren.length > 0);
+  assertEquals(true, !!prependCall, "Prepend for simple object incorrect.");
+  if (prependCall) {
+    const prependedElement = prependCall.element.prependedChildren[0];
+    assertEquals(true, !!prependedElement, "A child element should have been prepended for simple object.");
+    if (prependedElement) {
+      const prependedContentString = prependedElement.selector;
+      const expectedJsonInPayload = JSON.stringify(expectedRenderedArrayForAssertions, null, 2);
+      const expectedPayload = `\n    debug ${expectedJsonInPayload}\n    `;
+      assertEquals(expectedPayload, prependedContentString, "Rendered output for simple object incorrect.");
+    }
+  }
+
   assertEquals(5000, setTimeoutDuration, "setTimeout for simple object incorrect.");
-  assertEquals("debug", flintRemoveCalledOn, "$('debug').remove() for simple object incorrect.");
+  const removeCall = mock$.calls.find(call => call.originalSelector === 'debug' && call.element.removed);
+  assertEquals(true, !!removeCall, "$('debug').remove() for simple object incorrect.");
 }
 
 function testDebug_setTimeoutCallbackRemovesElement() {
-  resetMocksAndExpectedRenderedArray(); // Also clears expectedRenderedArrayForAssertions for this test
+  resetMocksAndExpectedRenderedArray();
   debug("Testing setTimeout callback");
-  // expectedRenderedArrayForAssertions will be ["Testing setTimeout callback"] if this runs first, or accumulated if not.
-  // This specific test doesn't assert flintPrependPayload, so accumulation doesn't affect its primary check.
+  // We don't need to check expectedRenderedArrayForAssertions for this specific test's main goal.
 
   assertEquals(true, typeof setTimeoutCallback === 'function', "setTimeout callback not a function.");
 
-  // Reset flintRemoveCalledOn after the initial call within debug() and before the callback runs,
-  // so we can specifically check if the callback sets it.
-  flintRemoveCalledOn = null;
+  mock$.reset(); // Reset calls before invoking the callback to isolate its effect.
 
-  setTimeoutCallback(); // Execute the callback. This should use the captured mockFlint$.
-                        // mockFlint$('debug').remove() should set flintRemoveCalledOn = "debug".
+  setTimeoutCallback(); // Execute the callback.
 
-  assertEquals("debug", flintRemoveCalledOn, "$('debug').remove() by timeout callback incorrect.");
+  const removeCall = mock$.calls.find(call => call.originalSelector === 'debug' && call.element.removed);
+  assertEquals(true, !!removeCall, "$('debug').remove() by timeout callback incorrect.");
 }
 
 // --- End Test Cases ---

--- a/client/flint.test.js
+++ b/client/flint.test.js
@@ -3,7 +3,7 @@ const { loadClientScript } = require('./testHelpers');
 const { assertEquals, runTests } = require('./testUtils');
 
 // Mock DOM Implementation
-const log = (message) => console.log(`[MockDOM] ${message}`);
+const log = (message) => {}; // console.log(`[MockDOM] ${message}`);
 
 const createMockElement = (tagName) => {
   log(`createMockElement called for: ${tagName}`);
@@ -22,12 +22,12 @@ const createMockElement = (tagName) => {
     appendChild: function(child) {
       let childIdentifier = child.tagName || child.textContent;
       if (child.nodeType === 11) childIdentifier = "#document-fragment"; // Explicitly log fragment
-      log(`${this.tagName} appendChild called with child: ${childIdentifier} (nodeType: ${child.nodeType})`);
+      // log(`${this.tagName} appendChild called with child: ${childIdentifier} (nodeType: ${child.nodeType})`);
       this.children.push(child);
       child.parentNode = this; // Set parentNode
     },
     setAttribute: function(name, value) {
-      log(`${this.tagName} setAttribute called with name: ${name}, value: ${value}`);
+      // log(`${this.tagName} setAttribute called with name: ${name}, value: ${value}`);
       this.attributes[name] = String(value); // Store as string, like HTML
       if (name === "style") {
         value.split(';').forEach(style => {
@@ -38,24 +38,24 @@ const createMockElement = (tagName) => {
       }
     },
     getAttribute: function(name) {
-      log(`${this.tagName} getAttribute called for name: ${name}`);
+      // log(`${this.tagName} getAttribute called for name: ${name}`);
       return this.attributes[name];
     },
     addEventListener: function(type, listener) {
-      log(`${this.tagName} addEventListener called for type: ${type}`);
+      // log(`${this.tagName} addEventListener called for type: ${type}`);
       if (!this.eventListeners[type]) {
         this.eventListeners[type] = [];
       }
       this.eventListeners[type].push(listener);
     },
     querySelectorAll: function(selector) {
-      log(`${this.tagName} querySelectorAll called with selector: ${selector}`);
+      // log(`${this.tagName} querySelectorAll called with selector: ${selector}`);
       const results = this.children.filter(child => child.tagName && child.tagName === selector.toUpperCase());
       results.forEach = Array.prototype.forEach; // Add forEach for NodeList mimicry
       return results;
     },
-    remove: function() { log(`${this.tagName} remove called`); },
-    focus: function() { log(`${this.tagName} focus called`); },
+    remove: function() { /* log(`${this.tagName} remove called`); */ },
+    focus: function() { /* log(`${this.tagName} focus called`); */ },
   };
 };
 
@@ -63,13 +63,13 @@ let mockDocumentObject = {
   constructor: { name: "HTMLDocumentMock" },
   _elements: [], // For global querySelectorAll, if needed
   createElement: function(tagName) {
-    log(`mockDocument.createElement called for: ${tagName}`);
+    // log(`mockDocument.createElement called for: ${tagName}`);
     const el = createMockElement(tagName);
     this._elements.push(el); // Track elements for global queries
     return el;
   },
   createTextNode: function(text) {
-    log(`mockDocument.createTextNode called with text: "${text}"`);
+    // log(`mockDocument.createTextNode called with text: "${text}"`);
     // Return a more element-like text node to prevent errors if flint tries to add helpers
     // that expect methods like querySelectorAll, even if they don't make sense for a text node.
     const textNode = createMockElement('#text'); // Use a special tagName for identification
@@ -89,7 +89,7 @@ let mockDocumentObject = {
     return textNode;
   },
   createDocumentFragment: function() {
-    log('mockDocument.createDocumentFragment called');
+    // log('mockDocument.createDocumentFragment called');
     const fragment = createMockElement('#document-fragment'); // Use a special tagName for fragments
     fragment.nodeType = 11; // Node.DOCUMENT_FRAGMENT_NODE
     return fragment;
@@ -127,10 +127,10 @@ let mockWindowObject = {
   document: mockDocument, // Use the callable mockDocument
   navigator: { userAgent: "NodeTestEnvironment/1.0" },
   addEventListener: function(type, listener) {
-    log(`mockWindow.addEventListener called for type: ${type}`);
+    // log(`mockWindow.addEventListener called for type: ${type}`);
   },
   removeEventListener: function(type, listener) {
-    log(`mockWindow.removeEventListener called for type: ${type}`);
+    // log(`mockWindow.removeEventListener called for type: ${type}`);
   }
 };
 const mockWindow = () => mockWindowObject; // Make it callable
@@ -146,13 +146,13 @@ const $ = loadClientScript(
 
 function testCreateSimpleDiv() {
   if (typeof $ !== 'function') {
-    console.error(`[TEST DEBUG] Flint $ is not a function. Actual type: ${typeof $}. Value: ${String($)}`);
+    // console.error(`[TEST DEBUG] Flint $ is not a function. Actual type: ${typeof $}. Value: ${String($)}`);
     // This will cause the test to fail, but gives a clear reason.
     assertEquals('function', typeof $, "Flint $ should be a function");
     return;
   }
   const $div = $("\n  div"); // Changed to standard string with escaped newline
-  console.log(`[TEST DEBUG] testCreateSimpleDiv: $div type is ${typeof $div}, value is ${String($div)}`);
+  // console.log(`[TEST DEBUG] testCreateSimpleDiv: $div type is ${typeof $div}, value is ${String($div)}`);
   assertEquals(true, !!$div, "Test Simple Div: element should be created");
   if (!$div) return; // Guard against further errors if creation failed
   assertEquals("DIV", $div.tagName, "Test Simple Div: tagName should be DIV");
@@ -249,7 +249,7 @@ function testArrayArgument() {
   mockChild2.innerText = "Child 2";
 
   const $div = $("\n  div $1", [[mockChild1, mockChild2]]);
-  console.log(`[TEST DEBUG] testArrayArgument: $div type is ${typeof $div}, value is ${String($div)}, tagName is ${$div ? $div.tagName : 'N/A'}, children count is ${$div ? ($div.children || []).length : 'N/A'}`);
+  // console.log(`[TEST DEBUG] testArrayArgument: $div type is ${typeof $div}, value is ${String($div)}, tagName is ${$div ? $div.tagName : 'N/A'}, children count is ${$div ? ($div.children || []).length : 'N/A'}`);
   assertEquals(true, !!$div, "Test Array Argument: DIV element should be created");
   if (!$div) return;
 
@@ -437,7 +437,7 @@ function testHelperOnMethod() {
 
   // Ensure eventListeners and addEventListener are present (they should be from createMockElement)
   if (!$el.eventListeners || typeof $el.addEventListener !== 'function') {
-    console.error("Mock element from selector doesn't have event listener capabilities from createMockElement.");
+    // console.error("Mock element from selector doesn't have event listener capabilities from createMockElement.");
     // This would indicate an issue with how mock elements are retrieved or created by selectors.
     // For now, we'll add them if missing, but this signals a deeper mock setup problem.
     $el.eventListeners = $el.eventListeners || {};

--- a/client/imageToPng.test.js
+++ b/client/imageToPng.test.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
 const path = require('path');
+const { loadClientScript } = require('./testHelpers');
 
 // Mocking browser environment
 let lastDrawImageArgs = null;
@@ -58,15 +58,14 @@ global.Image = function() {
 let imageToPng;
 
 try {
-  const imageToPngPath = path.resolve(__dirname, './imageToPng.js');
-  const imageToPngCode = fs.readFileSync(imageToPngPath, 'utf8');
-  imageToPng = new Function('Image', 'document', `${imageToPngCode}; return imageToPng;`)(
-    global.Image,
-    global.document
+  imageToPng = loadClientScript(
+    path.resolve(__dirname, './imageToPng.js'),
+    { Image: global.Image, document: global.document },
+    "imageToPng"
   );
 } catch (error) {
-  console.error("Failed to load imageToPng.js:", error);
-  process.exit(1); 
+  console.error("Failed to load imageToPng.js using loadClientScript:", error);
+  process.exit(1);
 }
 
 // Use the new testUtils


### PR DESCRIPTION
- Removed console.log statements from flint.test.js to reduce noise during test runs.
- Refactored imageToPng.test.js to use loadClientScript from testHelpers.js, aligning it with the recommended project pattern for loading client-side scripts.
- Standardized the mocking of the Flint ($) utility in debug.test.js by replacing its custom mock with the createMockDollar utility from testHelpers.js.
- I attempted to standardize $ mocking in markdownToElements.test.js but reverted the changes as createMockDollar was not suitable for its HTML output validation approach. The file retains its custom mockDollarUtil.

All tests pass after these changes.