### PR TITLE
Refactor: Remove unhelpful comments from test files

### DIFF
--- a/client/flint.test.js
+++ b/client/flint.test.js
@@ -3,10 +3,8 @@ const { loadClientScript } = require('./testHelpers');
 const { assertEquals, runTests } = require('./testUtils');
 
 // Mock DOM Implementation
-const log = (message) => {}; // console.log(`[MockDOM] ${message}`);
 
 const createMockElement = (tagName) => {
-  log(`createMockElement called for: ${tagName}`);
   const MOCK_ELEMENT_CONSTRUCTOR_NAME = "HTMLMockElement"; // Or specific like HTMLDivElementMock
 
   return {
@@ -22,12 +20,10 @@ const createMockElement = (tagName) => {
     appendChild: function(child) {
       let childIdentifier = child.tagName || child.textContent;
       if (child.nodeType === 11) childIdentifier = "#document-fragment"; // Explicitly log fragment
-      // log(`${this.tagName} appendChild called with child: ${childIdentifier} (nodeType: ${child.nodeType})`);
       this.children.push(child);
       child.parentNode = this; // Set parentNode
     },
     setAttribute: function(name, value) {
-      // log(`${this.tagName} setAttribute called with name: ${name}, value: ${value}`);
       this.attributes[name] = String(value); // Store as string, like HTML
       if (name === "style") {
         value.split(';').forEach(style => {
@@ -38,24 +34,21 @@ const createMockElement = (tagName) => {
       }
     },
     getAttribute: function(name) {
-      // log(`${this.tagName} getAttribute called for name: ${name}`);
       return this.attributes[name];
     },
     addEventListener: function(type, listener) {
-      // log(`${this.tagName} addEventListener called for type: ${type}`);
       if (!this.eventListeners[type]) {
         this.eventListeners[type] = [];
       }
       this.eventListeners[type].push(listener);
     },
     querySelectorAll: function(selector) {
-      // log(`${this.tagName} querySelectorAll called with selector: ${selector}`);
       const results = this.children.filter(child => child.tagName && child.tagName === selector.toUpperCase());
       results.forEach = Array.prototype.forEach; // Add forEach for NodeList mimicry
       return results;
     },
-    remove: function() { /* log(`${this.tagName} remove called`); */ },
-    focus: function() { /* log(`${this.tagName} focus called`); */ },
+    remove: function() {  },
+    focus: function() {  },
   };
 };
 
@@ -63,13 +56,11 @@ let mockDocumentObject = {
   constructor: { name: "HTMLDocumentMock" },
   _elements: [], // For global querySelectorAll, if needed
   createElement: function(tagName) {
-    // log(`mockDocument.createElement called for: ${tagName}`);
     const el = createMockElement(tagName);
     this._elements.push(el); // Track elements for global queries
     return el;
   },
   createTextNode: function(text) {
-    // log(`mockDocument.createTextNode called with text: "${text}"`);
     // Return a more element-like text node to prevent errors if flint tries to add helpers
     // that expect methods like querySelectorAll, even if they don't make sense for a text node.
     const textNode = createMockElement('#text'); // Use a special tagName for identification
@@ -89,7 +80,6 @@ let mockDocumentObject = {
     return textNode;
   },
   createDocumentFragment: function() {
-    // log('mockDocument.createDocumentFragment called');
     const fragment = createMockElement('#document-fragment'); // Use a special tagName for fragments
     fragment.nodeType = 11; // Node.DOCUMENT_FRAGMENT_NODE
     return fragment;
@@ -127,10 +117,8 @@ let mockWindowObject = {
   document: mockDocument, // Use the callable mockDocument
   navigator: { userAgent: "NodeTestEnvironment/1.0" },
   addEventListener: function(type, listener) {
-    // log(`mockWindow.addEventListener called for type: ${type}`);
   },
   removeEventListener: function(type, listener) {
-    // log(`mockWindow.removeEventListener called for type: ${type}`);
   }
 };
 const mockWindow = () => mockWindowObject; // Make it callable
@@ -146,13 +134,11 @@ const $ = loadClientScript(
 
 function testCreateSimpleDiv() {
   if (typeof $ !== 'function') {
-    // console.error(`[TEST DEBUG] Flint $ is not a function. Actual type: ${typeof $}. Value: ${String($)}`);
     // This will cause the test to fail, but gives a clear reason.
     assertEquals(typeof $, 'function', "Flint $ should be a function");
     return;
   }
   const $div = $("\n  div"); // Changed to standard string with escaped newline
-  // console.log(`[TEST DEBUG] testCreateSimpleDiv: $div type is ${typeof $div}, value is ${String($div)}`);
   assertEquals(!!$div, true, "Test Simple Div: element should be created");
   if (!$div) return; // Guard against further errors if creation failed
   assertEquals($div.tagName, "DIV", "Test Simple Div: tagName should be DIV");
@@ -249,7 +235,6 @@ function testArrayArgument() {
   mockChild2.innerText = "Child 2";
 
   const $div = $("\n  div $1", [[mockChild1, mockChild2]]);
-  // console.log(`[TEST DEBUG] testArrayArgument: $div type is ${typeof $div}, value is ${String($div)}, tagName is ${$div ? $div.tagName : 'N/A'}, children count is ${$div ? ($div.children || []).length : 'N/A'}`);
   assertEquals(!!$div, true, "Test Array Argument: DIV element should be created");
   if (!$div) return;
 
@@ -437,7 +422,6 @@ function testHelperOnMethod() {
 
   // Ensure eventListeners and addEventListener are present (they should be from createMockElement)
   if (!$el.eventListeners || typeof $el.addEventListener !== 'function') {
-    // console.error("Mock element from selector doesn't have event listener capabilities from createMockElement.");
     // This would indicate an issue with how mock elements are retrieved or created by selectors.
     // For now, we'll add them if missing, but this signals a deeper mock setup problem.
     $el.eventListeners = $el.eventListeners || {};

--- a/client/testHelpers.js
+++ b/client/testHelpers.js
@@ -92,28 +92,23 @@ function createMockDollar() {
       
       remove: function() { 
         this.removed = true; 
-        // console.log(`Mock element '${this.selector}' remove called`);
       },
       prepend: function(childElement) { 
         // Child might be a string or another mockElement
         this.prependedChildren.push(childElement); 
-        // console.log(`Mock element '${this.selector}' prepend called with:`, childElement);
       },
       append: function(childElement) { 
         this.appendedChildren.push(childElement); 
-        // console.log(`Mock element '${this.selector}' append called with:`, childElement);
       },
       on: function(eventName, handler) { 
         this.eventHandlers[eventName] = this.eventHandlers[eventName] || [];
         this.eventHandlers[eventName].push(handler); 
-        // console.log(`Mock element '${this.selector}' on '${eventName}' handler added`);
       },
       attr: function(attributeName, value) { 
         if (value === undefined) {
           return this.attributes[attributeName];
         }
         this.attributes[attributeName] = value;
-        // console.log(`Mock element '${this.selector}' attr '${attributeName}' set to:`, value);
         return this; // for chaining
       },
       text: function(content) {
@@ -121,7 +116,6 @@ function createMockDollar() {
           return this.textContent;
         }
         this.textContent = String(content); // Ensure content is stringified
-        // console.log(`Mock element '${this.selector}' text set to:`, content);
         return this;
       },
       val: function(v_content) { // Renamed to avoid conflict with 'value' property
@@ -129,23 +123,19 @@ function createMockDollar() {
           return this.value;
         }
         this.value = v_content;
-        // console.log(`Mock element '${this.selector}' val set to:`, v_content);
         return this;
       },
       focus: function() { 
         this.focused = true; 
-        // console.log(`Mock element '${this.selector}' focus called`);
       },
       empty: function() { 
         this.prependedChildren = []; 
         this.appendedChildren = []; 
         this.textContent = ''; 
         // Potentially clear other fields like attributes or value if needed by tests
-        // console.log(`Mock element '${this.selector}' empty called`);
         return this;
       },
       $: function(subSelector, subArgs) { // Chained call
-        // console.log(`Mock element '${this.selector}' chained $ call with selector: '${subSelector}'`);
         return mockDollar(subSelector, subArgs); // Uses the parent mockDollar to ensure tracking
       },
       // Add setAttribute as an alias for attr to handle tests for code using either
@@ -178,7 +168,6 @@ function createMockDollar() {
   mockDollar.reset = () => {
     mockDollar.calls = [];
     mockDollar.primedProperties = {}; // Reset primed properties as well
-    // console.log('mockDollar.calls reset');
   };
 
   mockDollar.primeElementProperties = function(selector, properties) {


### PR DESCRIPTION
I removed commented-out console.log statements and unused log functions from `client/testHelpers.js` and `client/flint.test.js`.

This is a small cleanup step to improve readability and prepare for future refactoring of test mocking strategies.