### PR TITLE
Refactor: Clarify comment for Mock DOM implementation

### DIFF
--- a/client/testHelpers.js
+++ b/client/testHelpers.js
@@ -177,7 +177,7 @@ function createMockDollar() {
   return mockDollar;
 }
 
-// Mock DOM Implementation (copied and adapted from flint.test.js)
+// Mock DOM Implementation
 
 const createMockElement = (tagName) => {
   const MOCK_ELEMENT_CONSTRUCTOR_NAME = "HTMLMockElement"; // Or specific like HTMLDivElementMock


### PR DESCRIPTION
The comment in `client/testHelpers.js` regarding the origin of the Mock DOM helper functions (`createMockElement`, `createMockDocument`, `createMockWindow`) was outdated.

These functions are now canonical in `client/testHelpers.js`, and `flint.test.js` (the referenced original source) consumes them from this file.

The comment has been updated from:
`// Mock DOM Implementation (copied and adapted from flint.test.js)` to:
`// Mock DOM Implementation`

This change improves clarity about the source of these utilities and is a small step towards better consistency in test mocking. No functional code was changed, and all tests continue to pass.