### PR TITLE
Refactor: Clarify comments on Flint mocking strategies

### DIFF
--- a/client/debug.test.js
+++ b/client/debug.test.js
@@ -2,7 +2,8 @@ const { assertEquals, runTests } = require('./testUtils');
 const { loadClientScript, createMockDollar, createMockDocument, createMockWindow } = require('./testHelpers');
 const path = require('path');
 
-// --- Mock DOM Environment ---
+// --- Mock Environment Setup ---
+// Mock for Flint's `$` functionality
 const mock$ = createMockDollar();
 let setTimeoutCallback = null;
 let setTimeoutDuration = 0;
@@ -11,7 +12,9 @@ let setTimeoutDuration = 0;
 let expectedRenderedArrayForAssertions = [];
 
 // Initialize Mock DOM using Imported Utilities
+// Provides the global `document` object required by `loadClientScript` for `debug.js`
 const mockDocumentInstance = createMockDocument();
+// Provides the global `window` object required by `loadClientScript` for `debug.js`
 const mockWindowInstance = createMockWindow(mockDocumentInstance);
 
 // Retain existing mock setTimeout logic by adding it to the mockWindowInstance

--- a/client/goToPath.test.js
+++ b/client/goToPath.test.js
@@ -43,6 +43,9 @@ const mockModalInfo = createMockFunction('modalInfo');
 const mockLoadingPage = createMockFunction('loadingPage');
 const mockStartSession = createMockFunction('startSession');
 const mock$ = createMockDollar(); // From testHelpers.js
+// This mock$ is for simulating Flint's `$` library. It's distinct from
+// mockWindow and mockDocument, which are manually created below to mock the
+// global browser environment for the goToPath.js script.
 
 const mockState = {
   path: '', // Initialized in setupMocksAndState

--- a/client/testHelpers.js
+++ b/client/testHelpers.js
@@ -61,6 +61,8 @@ function loadClientScript(filePath, globalMocks, constNamesToReturn) {
  * This mock is intended for tests where flint.js itself is not the direct subject under test,
  * but rather its interactions need to be simulated.
  * The returned mockDollar function tracks its calls and the behavior of created elements.
+ * This is one of two primary methods used in this codebase for testing Flint-dependent code;
+ * see the comment block around lines 60-77 for a comparison with the alternative approach.
  * @returns {Function} The mockDollar function, which also has a .calls array and .reset() method.
  */
 function createMockDollar() {


### PR DESCRIPTION
I've updated comments in your test files (debug.test.js, goToPath.test.js) and testHelpers.js to more clearly distinguish between the two approaches for testing code involving Flint.js:

1. Using `createMockDollar` to mock Flint's `$` function.
2. Using a mock DOM environment with the actual `flint.js` script.

This clarification aims to reduce confusion and serves as a preparatory step for future refactoring towards a unified Flint testing strategy. No code logic was changed.