### PR TITLE
Refactor: Improve comment cross-reference in testHelpers.js

### DIFF
--- a/client/testHelpers.js
+++ b/client/testHelpers.js
@@ -62,7 +62,7 @@ function loadClientScript(filePath, globalMocks, constNamesToReturn) {
  * but rather its interactions need to be simulated.
  * The returned mockDollar function tracks its calls and the behavior of created elements.
  * This is one of two primary methods used in this codebase for testing Flint-dependent code;
- * see the comment block around lines 60-77 for a comparison with the alternative approach.
+ * see the comment block starting with 'Mock DOM Implementation for testing flint.js itself' for a comparison with the alternative approach.
  * @returns {Function} The mockDollar function, which also has a .calls array and .reset() method.
  */
 function createMockDollar() {


### PR DESCRIPTION
Replaces a line-number-based cross-reference in the JSDoc for createMockDollar within client/testHelpers.js with a content-based reference.

The previous reference pointed to a comment block explaining the dual mocking strategies for Flint using line numbers (e.g., "lines 150-161"). This approach is brittle as line numbers change frequently with code edits.

The updated comment now refers to the explanatory block by a unique phrase from its content ("see the comment block starting with 'Mock DOM Implementation for testing flint.js itself'"). This makes the documentation more resilient to future changes in the file.