### PR TITLE
Refactor: Add _tag property to createMockDollar elements

### DIFF
--- a/client/markdownToElements.test.js
+++ b/client/markdownToElements.test.js
@@ -669,6 +669,7 @@ const allTestFunctions = [
     testImages,
     testLinks,
     testAutomaticUrlLinking,
+    testMockDollarTagProperty,
 ];
 
 // --- Main execution ---
@@ -678,3 +679,34 @@ runTestsFromUtils("markdownToElements.test.js", allTestFunctions).catch(err => {
   console.error("\nCritical Error during test execution:", err);
   process.exit(1); 
 });
+
+function testMockDollarTagProperty() {
+    const dollar = createMockDollar(); // Use the imported createMockDollar
+
+    let element = dollar("div[id=test]");
+    assertEquals(element._tag, "div", "Test mockDollar _tag: div[id=test]");
+
+    element = dollar("span.myClass");
+    assertEquals(element._tag, "span", "Test mockDollar _tag: span.myClass");
+
+    element = dollar("button");
+    assertEquals(element._tag, "button", "Test mockDollar _tag: button");
+
+    element = dollar("#myId");
+    assertEquals(element._tag, undefined, "Test mockDollar _tag: #myId");
+
+    element = dollar(".myClass");
+    assertEquals(element._tag, undefined, "Test mockDollar _tag: .myClass");
+
+    // Test with template string
+    element = dollar("h1 $1", ["Test Title"]);
+    assertEquals(element._tag, "h1", "Test mockDollar _tag: h1 $1");
+
+    // Test with an empty string selector
+    element = dollar("");
+    assertEquals(element._tag, undefined, "Test mockDollar _tag: empty string");
+
+    // Test with a selector that is only special characters (edge case for regex)
+    element = dollar("[attr=val]");
+    assertEquals(element._tag, undefined, "Test mockDollar _tag: [attr=val]");
+}

--- a/client/testHelpers.js
+++ b/client/testHelpers.js
@@ -93,6 +93,7 @@ function createMockDollar() {
       value: '',
       scrollTop: 0, // Default scrollTop property
       focused: false,
+      _tag: undefined, // Initialize _tag property
       
       remove: function() { 
         this.removed = true; 
@@ -147,6 +148,14 @@ function createMockDollar() {
         return this.attr(attributeName, value);
       },
     };
+
+    // Extract tag from selector
+    if (typeof processedSelector === 'string') {
+      const match = processedSelector.match(/^[a-zA-Z0-9]+/);
+      if (match && !processedSelector.startsWith('.') && !processedSelector.startsWith('#')) {
+        elementProperties._tag = match[0];
+      }
+    }
 
     // Check if there are primed properties for this selector
     if (mockDollar.primedProperties && mockDollar.primedProperties[processedSelector]) {


### PR DESCRIPTION
This change enhances the `createMockDollar` utility in `client/testHelpers.js` by adding a `_tag` property to the mock elements it generates. The tag is extracted from the selector string (e.g., "div" from "div.class" or "div#id"). If the selector does not specify a tag (e.g., ".class" or "#id"), the `_tag` property will be undefined.

This is the first incremental step towards consolidating the functionality of `createMockFlintElement` (from `modals.test.js`) into `createMockDollar`, with the eventual goal of having `modals.test.js` use the more centralized `createMockDollar`.

A new test case, `testMockDollarTagProperty`, has been added to `client/markdownToElements.test.js` to verify this new `_tag` property. All client-side tests pass with this change.