### PR TITLE
Refactor: Use common test helpers in websocket.test.js

### DIFF
--- a/tests/websocket.test.js
+++ b/tests/websocket.test.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { assertEquals, runTests } = require('./testUtils');
-const { loadClientScript, createMockFunction } = require('./testHelpers');
+const { loadClientScript, createMockFunction, createMockDocument, createMockWindow } = require('./testHelpers');
 
 // Mock global dependencies
 let mockState;
@@ -18,11 +18,10 @@ const setupMocks = () => {
     path: '/initial-path',
   };
 
-  mockWindow = {
-    location: {
-      host: 'testhost.com',
-    },
-  };
+  const mockDocument = createMockDocument(); // Create a mock document
+  mockWindow = createMockWindow(mockDocument); // Create mock window, passing the document
+  mockWindow.location = {}; // Initialize location object
+  mockWindow.location.host = 'testhost.com';
 
   // Mock WebSocket instance methods
   const mockAddEventListener = createMockFunction('websocket.addEventListener');


### PR DESCRIPTION
The `tests/websocket.test.js` file was manually creating a mock for the `window` object. This change refactors the test to use the `createMockDocument` and `createMockWindow` helper functions from `tests/testHelpers.js`.

This change improves consistency across tests and leverages shared testing utilities as intended. No functional changes to the websocket client or its tests are introduced. All tests continue to pass.