### PR TITLE
Fix: Correct assertEquals argument order in client unit tests

### DIFF
--- a/tests/client/unit/debug.test.js
+++ b/tests/client/unit/debug.test.js
@@ -190,7 +190,7 @@ function testDebug_setTimeoutCallbackRemovesElement() {
   debug("Testing setTimeout callback");
   // We don't need to check expectedRenderedArrayForAssertions for this specific test's main goal.
 
-  assertEquals(typeof setTimeoutCallback === 'function', true, "setTimeout callback not a function.");
+  assertEquals(true, typeof setTimeoutCallback === 'function', "setTimeout callback not a function.");
 
   // mock$.reset(); // Removed: mock$ is no longer used
 

--- a/tests/client/unit/flint.test.js
+++ b/tests/client/unit/flint.test.js
@@ -46,7 +46,7 @@ function testCreateSimpleDiv() {
     return;
   }
   const $div = $("\n  div"); // Changed to standard string with escaped newline
-  assertEquals(!!$div, true, "Test Simple Div: element should be created");
+  assertEquals(true, !!$div, "Test Simple Div: element should be created");
   if (!$div) return; // Guard against further errors if creation failed
   assertEquals($div.tagName, "DIV", "Test Simple Div: tagName should be DIV");
   assertEquals(typeof $div.attributes, "object", "Test Simple Div: attributes should be an object");
@@ -57,7 +57,7 @@ function testCreateSimpleDiv() {
 function testCreateParagraphWithText() {
   beforeEachFlintTest();
   const $p = $("\n  p Hello World");
-  assertEquals(!!$p, true, "Test P with Text: element should be created");
+  assertEquals(true, !!$p, "Test P with Text: element should be created");
   if (!$p) return;
   assertEquals($p.tagName, "P", "Test P with Text: tagName should be P");
   assertEquals($p.innerText, "Hello World", "Test P with Text: innerText should be 'Hello World'");
@@ -66,7 +66,7 @@ function testCreateParagraphWithText() {
 function testCreateInputWithAttributes() {
   beforeEachFlintTest();
   const $input = $("\n  input[type=text][name=testInput]");
-  assertEquals(!!$input, true, "Test Input with Attributes: element should be created");
+  assertEquals(true, !!$input, "Test Input with Attributes: element should be created");
   if (!$input) return;
   assertEquals($input.tagName, "INPUT", "Test Input with Attributes: tagName should be INPUT");
   assertEquals($input.getAttribute('type'), "text", "Test Input with Attributes: type attribute should be 'text'");
@@ -76,13 +76,13 @@ function testCreateInputWithAttributes() {
 function testCreateNestedElements() {
   beforeEachFlintTest();
   const $ul = $("\n  ul\n    li Item 1");
-  assertEquals(!!$ul, true, "Test Nested Elements: UL element should be created");
+  assertEquals(true, !!$ul, "Test Nested Elements: UL element should be created");
   if (!$ul) return;
   assertEquals($ul.tagName, "UL", "Test Nested Elements: UL tagName should be UL");
   assertEquals(($ul.children || []).length, 1, "Test Nested Elements: UL should have one child");
   if (($ul.children || []).length === 0) return;
   const $li = $ul.children[0];
-  assertEquals(!!$li, true, "Test Nested Elements: LI element should be created");
+  assertEquals(true, !!$li, "Test Nested Elements: LI element should be created");
   if (!$li) return;
   assertEquals($li.tagName, "LI", "Test Nested Elements: Child tagName should be LI");
   assertEquals($li.innerText, "Item 1", "Test Nested Elements: Child innerText should be 'Item 1'");
@@ -91,7 +91,7 @@ function testCreateNestedElements() {
 function testArgSubstitutionText() {
   beforeEachFlintTest();
   const $h1 = $("\n  h1 $1", ["Test Title"]);
-  assertEquals(!!$h1, true, "Test Arg Substitution Text: element should be created");
+  assertEquals(true, !!$h1, "Test Arg Substitution Text: element should be created");
   if (!$h1) return;
   assertEquals($h1.tagName, "H1", "Test Arg Substitution Text: tagName should be H1");
   assertEquals($h1.innerText, "Test Title", "Test Arg Substitution Text: innerText should be 'Test Title'");
@@ -100,7 +100,7 @@ function testArgSubstitutionText() {
 function testArgSubstitutionAttrValue() {
   beforeEachFlintTest();
   const $a = $("\n  a[href=$1][target=_blank]", ["/test-path"]);
-  assertEquals(!!$a, true, "Test Arg Substitution Attr Value: element should be created");
+  assertEquals(true, !!$a, "Test Arg Substitution Attr Value: element should be created");
   if (!$a) return;
   assertEquals($a.tagName, "A", "Test Arg Substitution Attr Value: tagName should be A");
   assertEquals($a.getAttribute('href'), "/test-path", "Test Arg Substitution Attr Value: href attribute should be '/test-path'");
@@ -110,7 +110,7 @@ function testArgSubstitutionAttrValue() {
 function testArgSubstitutionAttrKey() {
   beforeEachFlintTest();
   const $div = $("\n  div[$1=value]", ["data-dynamic-attr"]);
-  assertEquals(!!$div, true, "Test Arg Substitution Attr Key: element should be created");
+  assertEquals(true, !!$div, "Test Arg Substitution Attr Key: element should be created");
   if (!$div) return;
   assertEquals($div.tagName, "DIV", "Test Arg Substitution Attr Key: tagName should be DIV");
   assertEquals($div.getAttribute('data-dynamic-attr'), "value", "Test Arg Substitution Attr Key: dynamic attribute 'data-dynamic-attr' should be 'value'");
@@ -119,7 +119,7 @@ function testArgSubstitutionAttrKey() {
 function testCreateMultipleRootElements() {
   beforeEachFlintTest();
   const $container = $("\n  div[id=one]\n  p[id=two]");
-  assertEquals(!!$container, true, "Test Multiple Roots: Container should be created");
+  assertEquals(true, !!$container, "Test Multiple Roots: Container should be created");
   if (!$container) return;
 
   assertEquals($container.tagName, "DIV", "Test Multiple Roots: Container tagName should be DIV (wrapper)");
@@ -128,14 +128,14 @@ function testCreateMultipleRootElements() {
   if (($container.children || []).length < 2) return; // Guard
 
   const $child1 = $container.children[0];
-  assertEquals(!!$child1, true, "Test Multiple Roots: First child should exist");
+  assertEquals(true, !!$child1, "Test Multiple Roots: First child should exist");
   if ($child1) {
     assertEquals($child1.tagName, "DIV", "Test Multiple Roots: First child should be DIV");
     assertEquals($child1.getAttribute('id'), "one", "Test Multiple Roots: First child id should be 'one'");
   }
 
   const $child2 = $container.children[1];
-  assertEquals(!!$child2, true, "Test Multiple Roots: Second child should exist");
+  assertEquals(true, !!$child2, "Test Multiple Roots: Second child should exist");
   if ($child2) {
     assertEquals($child2.tagName, "P", "Test Multiple Roots: Second child should be P");
     assertEquals($child2.getAttribute('id'), "two", "Test Multiple Roots: Second child id should be 'two'");
@@ -150,7 +150,7 @@ function testArrayArgument() {
   mockChild2.innerText = "Child 2";
 
   const $div = $("\n  div $1", [[mockChild1, mockChild2]]);
-  assertEquals(!!$div, true, "Test Array Argument: DIV element should be created");
+  assertEquals(true, !!$div, "Test Array Argument: DIV element should be created");
   if (!$div) return;
 
   assertEquals($div.tagName, "DIV", "Test Array Argument: tagName should be DIV");
@@ -191,7 +191,7 @@ function testTextNodeArgument() {
   mockDocumentInstance.createTextNode = originalCreateTextNode;
 
   const $returnedNode = $("\n  $1", ["My Text Content"]);
-  assertEquals(!!$returnedNode, true, "Test Text Node Arg Return: A node should be returned.");
+  assertEquals(true, !!$returnedNode, "Test Text Node Arg Return: A node should be returned.");
   if (!$returnedNode) return;
 
   // Assuming the mock text node has nodeType and textContent
@@ -241,7 +241,7 @@ function testSelectSingleElement() {
   // mockDocumentInstance.createElement automatically adds it to mockDocumentInstance._elements
 
   const $el = $("#singleElement");
-  assertEquals(!!$el, true, "Test Select Single: Element should be found");
+  assertEquals(true, !!$el, "Test Select Single: Element should be found");
   if (!$el) {
     // No teardown needed here as setup handles the next test.
     return;
@@ -267,7 +267,7 @@ function testSelectMultipleElements() {
   // mockDocumentInstance.createElement automatically adds these to mockDocumentInstance._elements
 
   const $els = $(".multipleElements");
-  assertEquals(!!$els, true, "Test Select Multiple: Elements should be found");
+  assertEquals(true, !!$els, "Test Select Multiple: Elements should be found");
   if (!$els) {
     // No teardown needed here
     return;
@@ -305,7 +305,7 @@ function testNestedSelection() {
   // parentEl is now in mockDocumentInstance._elements due to createElement.
 
   const $parent = $("#parentForNested");
-  assertEquals(!!$parent, true, "Test Nested Selection: Parent element should be found");
+  assertEquals(true, !!$parent, "Test Nested Selection: Parent element should be found");
   if (!$parent) {
     // No teardown needed here
     return;
@@ -315,7 +315,7 @@ function testNestedSelection() {
   // The mockElement.querySelectorAll (from createMockElement in testHelpers.js) should handle this.
   // It filters children of the $parent element.
   const $child = $parent.$("p");
-  assertEquals(!!$child, true, "Test Nested Selection: Child element should be found");
+  assertEquals(true, !!$child, "Test Nested Selection: Child element should be found");
   if (!$child) {
     // No teardown needed here
     return;
@@ -339,7 +339,7 @@ function testHelperOnMethod() {
 
   const $el = $("#testButtonForOn"); // Select the element just created
 
-  assertEquals(!!$el, true, "Test .on(): Element should be found for testing .on()");
+  assertEquals(true, !!$el, "Test .on(): Element should be found for testing .on()");
   if (!$el) {
     // No teardown needed here
     return;
@@ -364,13 +364,13 @@ function testHelperOnMethod() {
   $el.on('click', mockClickHandler);
   $el.on('mouseover', mockMouseOverHandler);
 
-  assertEquals(!!$el.eventListeners['click'], true, "Test .on(): 'click' event should have listeners registered.");
+  assertEquals(true, !!$el.eventListeners['click'], "Test .on(): 'click' event should have listeners registered.");
   if ($el.eventListeners['click']) {
     assertEquals($el.eventListeners['click'].length, 1, "Test .on(): One click handler should be registered.");
     assertEquals($el.eventListeners['click'][0], mockClickHandler, "Test .on(): Correct click handler should be registered.");
   }
 
-  assertEquals(!!$el.eventListeners['mouseover'], true, "Test .on(): 'mouseover' event should have listeners registered.");
+  assertEquals(true, !!$el.eventListeners['mouseover'], "Test .on(): 'mouseover' event should have listeners registered.");
   if ($el.eventListeners['mouseover']) {
     assertEquals($el.eventListeners['mouseover'].length, 1, "Test .on(): One mouseover handler should be registered.");
     assertEquals($el.eventListeners['mouseover'][0], mockMouseOverHandler, "Test .on(): Correct mouseover handler should be registered.");
@@ -387,7 +387,7 @@ function testHelperForEachSingleElement() {
   // mockDocumentInstance.createElement automatically adds it to mockDocumentInstance._elements
 
   const $el = $("#testDivForForEachSingle");
-  assertEquals(!!$el, true, "Test .forEach() Single: Element should be found");
+  assertEquals(true, !!$el, "Test .forEach() Single: Element should be found");
   if (!$el) {
     // No teardown needed here
     return;
@@ -423,7 +423,7 @@ function testHelperForEachMultipleElements() {
   // mockDocumentInstance.createElement automatically adds them to mockDocumentInstance._elements
 
   const $els = $(".testClassForForEach");
-  assertEquals(!!$els && typeof $els.forEach === 'function', true, "Test .forEach() Multiple: NodeList-like object should be returned");
+  assertEquals(true, !!$els && typeof $els.forEach === 'function', "Test .forEach() Multiple: NodeList-like object should be returned");
   if (!$els || typeof $els.forEach !== 'function') {
      // No teardown needed here
      return;

--- a/tests/client/unit/goToPath.test.js
+++ b/tests/client/unit/goToPath.test.js
@@ -175,19 +175,19 @@ function testNavigateToNewPath() {
   goToPath('/new-path', false, false);
 
   assertEquals(mockState.path, '/new-path', 'Should update state.path');
-  assertEquals(mockHistory.pushState.called, true, 'history.pushState should be called');
+  assertEquals(true, mockHistory.pushState.called, 'history.pushState should be called');
   assertEquals(mockHistory.pushState.callCount, 1, 'history.pushState call count');
   assertEquals(mockHistory.pushState.calls[0][2], '/new-path', 'history.pushState path argument');
   assertEquals(mockState.path_index, 1, 'state.path_index should increment');
 
 
-  assertEquals(mockLoadingPage.called, true, 'loadingPage should be called');
+  assertEquals(true, mockLoadingPage.called, 'loadingPage should be called');
   assertEquals(JSON.stringify(mockLoadingPage.calls[0]), JSON.stringify([false, false, false]), 'loadingPage arguments');
 
-  assertEquals(mockStartSession.called, true, 'startSession should be called');
+  assertEquals(true, mockStartSession.called, 'startSession should be called');
   assertEquals(JSON.stringify(mockStartSession.calls[0]), JSON.stringify([false]), 'startSession arguments (was_same_path false)');
 
-  assertEquals(mockState.ws.send.called, true, 'ws.send should be called');
+  assertEquals(true, mockState.ws.send.called, 'ws.send should be called');
   assertEquals(mockState.ws.send.calls[0][0], JSON.stringify({ path: '/new-path' }), 'ws.send arguments');
 }
 
@@ -200,9 +200,9 @@ function testModalShownIfTermsNotAgreed() {
 
   goToPath('/some-restricted-path', false, false);
 
-  assertEquals(mockModalInfo.called, true, 'modalInfo should be called for restricted path without agreement');
+  assertEquals(true, mockModalInfo.called, 'modalInfo should be called for restricted path without agreement');
   assertEquals(mockModalInfo.calls[0][0], 'Please tap "Join the Discussion" to agree to these terms.', 'modalInfo message');
-  assertEquals(mockHistory.pushState.called, false, 'history.pushState should NOT be called');
+  assertEquals(false, mockHistory.pushState.called, 'history.pushState should NOT be called');
   assertEquals(mockLoadingPage.called, false, 'loadingPage should NOT be called');
   assertEquals(mockStartSession.called, false, 'startSession should NOT be called');
 }
@@ -219,7 +219,7 @@ function testUsesTopicsPreferenceFromLocalStorage() {
   goToPath('/topics', false, false);
 
   assertEquals(mockState.path, preferredPath, 'state.path should be the preferred topics path');
-  assertEquals(mockHistory.pushState.called, true, 'history.pushState should be called for preferred path');
+  assertEquals(true, mockHistory.pushState.called, 'history.pushState should be called for preferred path');
   assertEquals(mockHistory.pushState.calls[0][2], preferredPath, 'history.pushState path argument for preferred path');
 }
 
@@ -270,9 +270,9 @@ function testHandlesTagPathAsActionTags() {
 
   goToPath('/tag/some-tag', false, false);
 
-  assertEquals(mockLoadingPage.called, true, 'loadingPage should be called for /tag/ path');
+  assertEquals(true, mockLoadingPage.called, 'loadingPage should be called for /tag/ path');
   // Arguments: loadingPage(false, skip_state, clicked_back)
-  assertEquals(mockLoadingPage.calls[0][0], false, 'loadingPage arg1 (show_loading_animation) should be false');
+  assertEquals(false, mockLoadingPage.calls[0][0], 'loadingPage arg1 (show_loading_animation) should be false');
   assertEquals(mockLoadingPage.calls[0][1], false, 'loadingPage arg2 (skip_state) should be false');
   assertEquals(mockLoadingPage.calls[0][2], false, 'loadingPage arg3 (clicked_back) should be false for this /tag/ scenario');
   assertEquals(mockState.path, '/tag/some-tag', 'state.path should be the new /tag/some-tag path');
@@ -291,8 +291,8 @@ function testClickedBackTrueForBackwardNavigationInSequence() {
 
   goToPath('/', false, false); // Navigate to '/' (index 0)
 
-  assertEquals(mockLoadingPage.called, true, 'loadingPage should be called');
-  assertEquals(mockLoadingPage.calls[0][2], true, 'loadingPage clicked_back argument should be true for backward navigation');
+  assertEquals(true, mockLoadingPage.called, 'loadingPage should be called');
+  assertEquals(true, mockLoadingPage.calls[0][2], 'loadingPage clicked_back argument should be true for backward navigation');
 }
 
 function testClickedBackFalseForForwardNavigationInSequence() {
@@ -307,8 +307,8 @@ function testClickedBackFalseForForwardNavigationInSequence() {
 
   goToPath('/topics', false, false); // Navigate to '/topics' (index 1)
 
-  assertEquals(mockLoadingPage.called, true, 'loadingPage should be called');
-  assertEquals(mockLoadingPage.calls[0][2], false, 'loadingPage clicked_back argument should be false for forward navigation');
+  assertEquals(true, mockLoadingPage.called, 'loadingPage should be called');
+  assertEquals(false, mockLoadingPage.calls[0][2], 'loadingPage clicked_back argument should be false for forward navigation');
 }
 
 function testFooterDotIndexSetCorrectly() {
@@ -359,15 +359,15 @@ function testStoresLastRootPathInLocalStorage() {
   };
 
   goToPath('/topics', false, false);
-  assertEquals(mockLocalStorage.setItem.called, true, 'localStorage.setItem should be called');
+  assertEquals(true, mockLocalStorage.setItem.called, 'localStorage.setItem should be called');
   const setItemCall = mockLocalStorage.setItem.calls.find(call => call[0] === `${mockWindow.local_storage_key}:last_root_path`);
-  assertEquals(!!setItemCall, true, 'last_root_path should be set in localStorage');
+  assertEquals(true, !!setItemCall, 'last_root_path should be set in localStorage');
   assertEquals(setItemCall[1], '/topics', 'last_root_path value');
 
   mockLocalStorage.setItem.reset();
   goToPath('/tag/a-tag', false, false);
   const setItemCallTag = mockLocalStorage.setItem.calls.find(call => call[0] === `${mockWindow.local_storage_key}:last_root_path`);
-  assertEquals(!!setItemCallTag, true, 'last_root_path should be set for /tag/ paths');
+  assertEquals(true, !!setItemCallTag, 'last_root_path should be set for /tag/ paths');
   assertEquals(setItemCallTag[1], '/tag/a-tag', 'last_root_path value for /tag/a-tag');
 
 }
@@ -404,8 +404,8 @@ function testDoesNotClearItemsIfPathIsSame() {
 
   assertEquals(mockState.active_add_new_comment, comment, 'active_add_new_comment should not be cleared');
   assertEquals(mockState.active_add_new_topic, topic, 'active_add_new_topic should not be cleared');
-  assertEquals(mockStartSession.called, true, 'startSession should be called');
-  assertEquals(mockStartSession.calls[0][0], true, 'startSession was_same_path argument should be true');
+  assertEquals(true, mockStartSession.called, 'startSession should be called');
+  assertEquals(true, mockStartSession.calls[0][0], 'startSession was_same_path argument should be true');
 }
 
 

--- a/tests/client/unit/imageToPng.test.js
+++ b/tests/client/unit/imageToPng.test.js
@@ -139,8 +139,8 @@ function runImageTest({
         assertEquals(result.url, expectedDataUrl, `${testName}: Should convert to PNG successfully`);
         assertEquals(result.width, expectedCanvasWidth, `${testName}: Result canvas width should be ${expectedCanvasWidth}`);
         assertEquals(result.height, expectedCanvasHeight, `${testName}: Result canvas height should be ${expectedCanvasHeight}`);
-        assertEquals(!!lastDrawImageArgs, true, `${testName}: drawImage should have been called`);
-        assertEquals(toDataURLCalled, true, `${testName}: toDataURL('image/png') should have been called`);
+        assertEquals(true, !!lastDrawImageArgs, `${testName}: drawImage should have been called`);
+        assertEquals(true, toDataURLCalled, `${testName}: toDataURL('image/png') should have been called`);
         assertEquals(mockCanvas.width, expectedCanvasWidth, `${testName}: Mock canvas width should be set to ${expectedCanvasWidth}`);
         assertEquals(mockCanvas.height, expectedCanvasHeight, `${testName}: Mock canvas height should be set to ${expectedCanvasHeight}`);
 
@@ -156,7 +156,7 @@ function runImageTest({
         // So, we re-throw the error to be caught by runTestsFromUtils's try-catch block around testFn().
         // Or, ensure assertEquals correctly reports failures that runTestsFromUtils can see.
         // For now, let's make sure assertEquals is called for failures.
-        assertEquals(false, true, `${testName}: Error during callback assertions: ${e.message}`);
+        assertEquals(true, false, `${testName}: Error during callback assertions: ${e.message}`);
         reject(e); // Keep reject to stop this specific Promise chain
       } finally {
         mockCanvas.toDataURL = originalToDataURL; // Restore original
@@ -168,7 +168,7 @@ function runImageTest({
     if (!global.Image.lastInstance) {
       // This indicates a fundamental issue with the test setup or the Image mock.
       // Report it as a failed assertion.
-      assertEquals(false, true, `[${testName}]: No image instance was created.`);
+      assertEquals(true, false, `[${testName}]: No image instance was created.`);
       return reject(new Error(`[${testName}] No image instance created.`));
     }
     
@@ -181,7 +181,7 @@ function runImageTest({
       global.Image.lastInstance.height = imgHeight;
       global.Image.lastInstance.onload();
     } else {
-      assertEquals(false, true, `[${testName}]: Image onload was not set or lastInstance is not available.`);
+      assertEquals(true, false, `[${testName}]: Image onload was not set or lastInstance is not available.`);
       return reject(new Error(`[${testName}] Image onload not set.`));
     }
   });
@@ -232,14 +232,14 @@ async function testImageLoadError() {
   try {
     await callbackPromise; // Wait for the main callback from imageToPng
 
-    assertEquals(mainCallbackCalled, true, `${testName}: Main callback should have been called.`);
+    assertEquals(true, mainCallbackCalled, `${testName}: Main callback should have been called.`);
     assertEquals(typeof mainCallbackArgs, "object", `${testName}: Callback argument should be an object.`);
     if (mainCallbackArgs === null || typeof mainCallbackArgs === 'undefined') {
       // Fail explicitly if mainCallbackArgs is null/undefined, to avoid error on next lines
-      assertEquals(false, true, `${testName}: mainCallbackArgs is null or undefined.`);
+      assertEquals(true, false, `${testName}: mainCallbackArgs is null or undefined.`);
       return; // Stop further execution in this test
     }
-    assertEquals(mainCallbackArgs.error, true, `${testName}: Callback argument should have 'error: true'.`);
+    assertEquals(true, mainCallbackArgs.error, `${testName}: Callback argument should have 'error: true'.`);
     assertEquals(mainCallbackArgs.message, "Image failed to load", `${testName}: Callback argument should have correct error message.`);
 
     // Check that the image src was indeed set to the invalid source on the mock
@@ -247,12 +247,12 @@ async function testImageLoadError() {
       assertEquals(global.Image.lastInstance.src, "invalid-image-source", `${testName}: Image src should be set to invalid-image-source on the mock.`);
     } else {
       // This should ideally be caught by the reject in the Promise if !global.Image.lastInstance
-      assertEquals(false, true, `${testName}: global.Image.lastInstance was unexpectedly null after test execution.`);
+      assertEquals(true, false, `${testName}: global.Image.lastInstance was unexpectedly null after test execution.`);
     }
 
   } catch (error) {
     // If callbackPromise rejected (e.g. timeout or explicit reject), it will be caught here.
-    assertEquals(false, true, `${testName}: Test failed: ${error.message}`);
+    assertEquals(true, false, `${testName}: Test failed: ${error.message}`);
   }
 }
 

--- a/tests/client/unit/renderBack.test.js
+++ b/tests/client/unit/renderBack.test.js
@@ -104,7 +104,7 @@ function testBackButtonNotRendered_RootPath() {
   global.state.path_index = 0;
   renderBack();
   const backButtonWrapper = $('main-content-wrapper[active] main-content .back-forward-wrapper');
-  assertEquals(!backButtonWrapper || backButtonWrapper.length === 0, true, "Test Case 1: Back button wrapper should not exist for root path.");
+  assertEquals(true, !backButtonWrapper || backButtonWrapper.length === 0, "Test Case 1: Back button wrapper should not exist for root path.");
 }
 
 function testBackButtonNotRendered_TopicsPath() {
@@ -114,7 +114,7 @@ function testBackButtonNotRendered_TopicsPath() {
   global.state.path_index = 0;
   renderBack();
   const backButtonWrapper = $('main-content-wrapper[active] main-content .back-forward-wrapper');
-  assertEquals(!backButtonWrapper || backButtonWrapper.length === 0, true, "Test Case 2: Back button wrapper should not exist for /topics path if it's the only history.");
+  assertEquals(true, !backButtonWrapper || backButtonWrapper.length === 0, "Test Case 2: Back button wrapper should not exist for /topics path if it's the only history.");
 }
 
 function testBackButtonRendered_TopicPath_DisplaysTitle() {
@@ -126,14 +126,14 @@ function testBackButtonRendered_TopicPath_DisplaysTitle() {
   renderBack();
 
   const mainContent = $('main-content-wrapper[active] main-content');
-  assertEquals(mainContent && mainContent.children && mainContent.children.length > 0, true, "Test Case 3: Main content should have children.");
+  assertEquals(true, mainContent && mainContent.children && mainContent.children.length > 0, "Test Case 3: Main content should have children.");
   
   const backButtonWrapperElement = mainContent.children[0]; // This is <back-forward-wrapper>
-  assertEquals(backButtonWrapperElement.tagName === 'BACK-FORWARD-WRAPPER', true, "Test Case 3: Correct wrapper is prepended (tag check).");
+  assertEquals(true, backButtonWrapperElement.tagName === 'BACK-FORWARD-WRAPPER', "Test Case 3: Correct wrapper is prepended (tag check).");
 
   const backButtonTextElement = $('main-content-wrapper[active] main-content back-forward-wrapper back-wrapper p');
   const backButtonText = backButtonTextElement ? backButtonTextElement.innerText : "";
-  assertEquals(backButtonText.includes("Topics"), true, `Test Case 3: Button text includes 'Topics'. Actual: '${backButtonText}'`);
+  assertEquals(true, backButtonText.includes("Topics"), `Test Case 3: Button text includes 'Topics'. Actual: '${backButtonText}'`);
 }
 
 function testBackButtonRendered_TopicPath_ClickNavigates() {
@@ -145,7 +145,7 @@ function testBackButtonRendered_TopicPath_ClickNavigates() {
   renderBack();
   
   const backWrapperToClick = $('main-content-wrapper[active] main-content back-forward-wrapper back-wrapper');
-  assertEquals(!!backWrapperToClick, true, "Test Case 4: Back wrapper element exists.");
+  assertEquals(true, !!backWrapperToClick, "Test Case 4: Back wrapper element exists.");
   
   if (backWrapperToClick && typeof backWrapperToClick.click === 'function') {
       backWrapperToClick.click();
@@ -153,12 +153,12 @@ function testBackButtonRendered_TopicPath_ClickNavigates() {
     backWrapperToClick.eventListeners.click.forEach(handler => handler.call(backWrapperToClick));
   } else {
     console.error("Click handler not found or not callable for back wrapper in Test Case 4. Element:", backWrapperToClick);
-    assertEquals(false, true, "Test Case 4: Click handler should be registered and callable on back wrapper.");
+    assertEquals(true, false, "Test Case 4: Click handler should be registered and callable on back wrapper.");
   }
 
   assertEquals(global.goToPath.lastCall.path, "/topics", "Test Case 4: goToPath is called with correct path.");
   assertEquals(global.goToPath.lastCall.skip_state, false, "Test Case 4: goToPath is called with skip_state false.");
-  assertEquals(global.goToPath.lastCall.clicked_back, true, "Test Case 4: goToPath is called with clicked_back true.");
+  assertEquals(true, global.goToPath.lastCall.clicked_back, "Test Case 4: goToPath is called with clicked_back true.");
 }
 
 function testBackButtonRendered_CommentPath_DisplaysGenericText() {
@@ -171,7 +171,7 @@ function testBackButtonRendered_CommentPath_DisplaysGenericText() {
 
   const backButtonTextElement = $('main-content-wrapper[active] main-content back-forward-wrapper back-wrapper p');
   const backButtonText = backButtonTextElement ? backButtonTextElement.innerText : "";
-  assertEquals(backButtonText.includes("Some Topic"), true, `Test Case 5: Button text is 'Some Topic'. Actual: '${backButtonText}'`);
+  assertEquals(true, backButtonText.includes("Some Topic"), `Test Case 5: Button text is 'Some Topic'. Actual: '${backButtonText}'`);
 }
 
 function testBackButtonRendered_UserPath_DisplaysRenderName() {
@@ -185,7 +185,7 @@ function testBackButtonRendered_UserPath_DisplaysRenderName() {
 
   const backButtonTextElement = $('main-content-wrapper[active] main-content back-forward-wrapper back-wrapper p');
   const backButtonText = backButtonTextElement ? backButtonTextElement.innerText : "";
-  assertEquals(backButtonText.includes("Topics"), true, `Test Case 6: Button text includes 'Topics'. Actual: '${backButtonText}'`);
+  assertEquals(true, backButtonText.includes("Topics"), `Test Case 6: Button text includes 'Topics'. Actual: '${backButtonText}'`);
 }
 
 function testBackButtonRendered_PathWithThreeSegments_CorrectPreviousPath() {
@@ -203,7 +203,7 @@ function testBackButtonRendered_PathWithThreeSegments_CorrectPreviousPath() {
 
   const backButtonTextElement = $('main-content-wrapper[active] main-content back-forward-wrapper back-wrapper p');
   const backButtonText = backButtonTextElement ? backButtonTextElement.innerText : "";
-  assertEquals(backButtonText.includes("Back"), true, `Test Case 7: Button text contains 'Back'. Actual: '${backButtonText}'`);
+  assertEquals(true, backButtonText.includes("Back"), `Test Case 7: Button text contains 'Back'. Actual: '${backButtonText}'`);
 
   const backWrapperToClick = $('main-content-wrapper[active] main-content back-forward-wrapper back-wrapper');
    if (backWrapperToClick && typeof backWrapperToClick.click === 'function') {
@@ -211,7 +211,7 @@ function testBackButtonRendered_PathWithThreeSegments_CorrectPreviousPath() {
   } else if (backWrapperToClick && backWrapperToClick.eventListeners && backWrapperToClick.eventListeners.click) {
     backWrapperToClick.eventListeners.click.forEach(handler => handler.call(backWrapperToClick));
   } else {
-     assertEquals(false, true, "Test Case 7: Click handler for back wrapper not found or not callable.");
+     assertEquals(true, false, "Test Case 7: Click handler for back wrapper not found or not callable.");
   }
   assertEquals(global.goToPath.lastCall.path, "/first", "Test Case 7: Click navigates to '/first'.");
 }
@@ -225,10 +225,10 @@ function testBackButtonRemoved_IfPreviousPathIsRootAndOnlyHistory() {
   renderBack();
   
   const backButtonToRoot = $('main-content-wrapper[active] main-content back-forward-wrapper back-wrapper');
-  assertEquals(!!backButtonToRoot, true, "Test Case 8a: Back button to root should be rendered.");
+  assertEquals(true, !!backButtonToRoot, "Test Case 8a: Back button to root should be rendered.");
   const backButtonToRootTextElement = $('main-content-wrapper[active] main-content back-forward-wrapper back-wrapper p');
   const backButtonToRootText = backButtonToRootTextElement ? backButtonToRootTextElement.innerText : "";
-  assertEquals(backButtonToRootText.includes("Terms and conditions"), true, `Test Case 8a: Button text is 'Terms and conditions'. Actual: '${backButtonToRootText}'`);
+  assertEquals(true, backButtonToRootText.includes("Terms and conditions"), `Test Case 8a: Button text is 'Terms and conditions'. Actual: '${backButtonToRootText}'`);
 
   beforeEach();
   global.state.path = "/nextpage";
@@ -237,7 +237,7 @@ function testBackButtonRemoved_IfPreviousPathIsRootAndOnlyHistory() {
   renderBack();
 
   const backButtonWrapper = $('main-content-wrapper[active] main-content .back-forward-wrapper');
-  assertEquals(!backButtonWrapper || backButtonWrapper.length === 0, true, "Test Case 8b: Back button wrapper is not rendered if no valid previous path.");
+  assertEquals(true, !backButtonWrapper || backButtonWrapper.length === 0, "Test Case 8b: Back button wrapper is not rendered if no valid previous path.");
 }
 
 const allTestFunctions = [


### PR DESCRIPTION
This commit corrects the argument order for `assertEquals` calls in several client-side unit test files. The `assertEquals` function expects the `expected` value as its first argument and the `actual` value as its second. Numerous callsites had these reversed, particularly when asserting boolean conditions.

The following files were updated:
- tests/client/unit/debug.test.js
- tests/client/unit/flint.test.js
- tests/client/unit/goToPath.test.js
- tests/client/unit/imageToPng.test.js
- tests/client/unit/renderBack.test.js

In each of these files, `assertEquals(actual, expected, message)` calls were changed to `assertEquals(expected, actual, message)`. This primarily affected assertions checking for truthiness (e.g., `assertEquals(!!value, true, ...)` is now `assertEquals(true, !!value, ...)`).

Additionally, I added the `jsdom` package as a dev dependency as it was missing and required for the test environment to run correctly. After installing `jsdom`, all unit and integration tests pass.