### PR TITLE
Refactor: Improve integration test organization and naming

### DIFF
--- a/tests/client/integration/general.integration.test.js
+++ b/tests/client/integration/general.integration.test.js
@@ -1,0 +1,13 @@
+const path = require('path');
+const { loadAllClientScripts } = require('../shared/testHelpers.js');
+const { assertEquals, runTests } = require('../shared/testUtils.js');
+
+const tests = {
+    testRealIndexHtmlLoads: () => {
+        const window = loadAllClientScripts(); // This should mock setTimeout and fetch
+        assertEquals(false, window.is_android);
+    }
+    // The testEditProfilePictureShowsErrorModal has been moved
+};
+
+runTests(path.basename(__filename), Object.values(tests));

--- a/tests/client/integration/profilePicture.integration.test.js
+++ b/tests/client/integration/profilePicture.integration.test.js
@@ -3,12 +3,7 @@ const { loadAllClientScripts } = require('../shared/testHelpers.js');
 const { assertEquals, runTests } = require('../shared/testUtils.js');
 
 const tests = {
-    testRealIndexHtmlLoads: () => {
-        const window = loadAllClientScripts(); // This should mock setTimeout and fetch
-        assertEquals(false, window.is_android);
-    },
-
-    testEditProfilePictureShowsErrorModal: async () => { // Ensure async
+    showsErrorModalOnProfilePictureUploadFailure: async () => { // Ensure async
         const window = loadAllClientScripts(); // This should mock setTimeout and fetch
 
         const originalImageToPng = window.imageToPng;


### PR DESCRIPTION
- I renamed `tests/client/integration/loadAllClientScripts.test.js` to `tests/client/integration/general.integration.test.js` to better reflect its general nature.
- I moved the profile picture related integration test to a new dedicated file: `tests/client/integration/profilePicture.integration.test.js`.
- I refined the test name within `profilePicture.integration.test.js` for clarity (from `testEditProfilePictureShowsErrorModal` to `showsErrorModalOnProfilePictureUploadFailure`).
- I ensured all integration tests pass after these changes.