### PR TITLE
Add integration tests for welcome page and terms agreement

### DIFF
--- a/tests/client/integration/profilePicture.integration.test.js
+++ b/tests/client/integration/profilePicture.integration.test.js
@@ -64,9 +64,9 @@ const tests = {
 
             if (errorModalContentElement) {
                 assertEquals(
-                    "Test error",
+                    "Test error: Unmocked fetch path",
                     errorModalContentElement.innerText.trim(),
-                    "Error message in modal should be 'Test error'."
+                    "Error message in modal should be 'Test error: Unmocked fetch path'."
                 );
             }
             window.document.body.removeChild(profilePictureContainer);

--- a/tests/client/integration/welcome.integration.test.js
+++ b/tests/client/integration/welcome.integration.test.js
@@ -1,0 +1,60 @@
+const path = require('path');
+const { loadAllClientScripts } = require('../shared/testHelpers.js');
+const { assertEquals, runTests } = require('../shared/testUtils.js');
+
+const tests = {
+    testInitialPageShowsWelcomeOrTerms: () => {
+        const window = loadAllClientScripts();
+        // The welcome header is specifically <h2 welcome><span>Terms and conditions</span></h2>
+        const welcomeHeaderSpan = window.document.querySelector('h2[welcome] span');
+
+        assertEquals(true, !!welcomeHeaderSpan, "Welcome header span should exist.");
+        if (welcomeHeaderSpan) {
+            assertEquals("Terms and conditions", welcomeHeaderSpan.innerText.trim(), "Initial page should display 'Terms and conditions' in the welcome header span.");
+        }
+
+        // Corrected selector for the "Join the Discussion" button
+        const joinButton = window.document.querySelector('a[href="/topics"][big]');
+        assertEquals(true, !!joinButton, "Initial page should have a 'Join the Discussion' button.");
+        if (joinButton) {
+            assertEquals("Join the Discussion", joinButton.innerText.trim(), "Button text should be 'Join the Discussion'.");
+        }
+    },
+
+    testAgreeingToTermsNavigatesToNextPageAndSetsLocalStorage: async () => {
+        const window = loadAllClientScripts();
+
+        // Corrected selector for the "Join the Discussion" button
+        const joinButton = window.document.querySelector('a[href="/topics"][big]');
+        assertEquals(true, !!joinButton, "Agree button should exist on the page.");
+        if (!joinButton) return; // Stop test if button not found
+
+        // Simulate a click
+        joinButton.click();
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // 1. Verify terms are no longer visible
+        const welcomeHeaderSpanAfterClick = window.document.querySelector('h2[welcome] span');
+        assertEquals(null, welcomeHeaderSpanAfterClick, "Welcome header span should NOT be present after agreeing to terms.");
+
+        // 2. Verify localStorage item is set
+        // The client-side code uses `localStorage.setItem(`${window.local_storage_key}:agreed`, true);`
+        // window.local_storage_key is set based on referrer or userAgent. In JSDOM, it defaults.
+        // The goToPath function refers to it as 'agreed' not 'truce_terms_agreed'
+        const termsAgreed = window.localStorage.getItem(window.local_storage_key ? `${window.local_storage_key}:agreed` : 'trucev1:agreed');
+        assertEquals("true", termsAgreed, `localStorage '${window.local_storage_key || 'trucev1'}:agreed' should be set to 'true'.`);
+
+        // 3. Verify new content is loaded (e.g., topics list)
+        const topicsWrapper = window.document.querySelector('topics');
+        assertEquals(true, !!topicsWrapper, "Topics wrapper element should be present after agreeing to terms.");
+
+        // Further check: The last_root_path in localStorage should be updated to /topics
+        // The client-side goToPath function updates this.
+        const lastRootPath = window.localStorage.getItem(window.local_storage_key ? `${window.local_storage_key}:last_root_path` : 'trucev1:last_root_path');
+        assertEquals("/topics", lastRootPath, "localStorage 'last_root_path' should be set to '/topics'.");
+    }
+};
+
+runTests(path.basename(__filename), Object.values(tests));

--- a/tests/client/shared/testHelpers.js
+++ b/tests/client/shared/testHelpers.js
@@ -499,7 +499,7 @@ function loadAllClientScripts() {
   const firstPassHtmlContent = parseIncludes(indexHtmlContent)
   // Parse the includes of includes
   const finalIndexHtmlContent = parseIncludes(firstPassHtmlContent)
-  // console.warn(finalIndexHtmlContent)
+  // console.warn("Final HTML content loaded into JSDOM:", finalIndexHtmlContent) // DEBUGGING: Log the final HTML
   const virtualConsole = new VirtualConsole()
   virtualConsole.sendTo(console)
   const dom = new JSDOM(finalIndexHtmlContent, {
@@ -509,7 +509,25 @@ function loadAllClientScripts() {
     includeNodeLocations: true,
     virtualConsole: virtualConsole,
     beforeParse(window) {
-      window.is_test = true
+      // window.is_test = true; // This prevents WebSocket initialization if not mocked
+
+      // Mock WebSocket to prevent JSDOM errors and allow state.ws.send to be called
+      window.WebSocket = function(url) {
+        console.log(`Mock WebSocket attempting to connect to: ${url}`);
+        this.send = function(data) {
+          console.log(`Mock WebSocket send: ${data}`);
+        };
+        this.close = function() {
+          console.log("Mock WebSocket close");
+        };
+        this.addEventListener = function(event, callback) {
+          console.log(`Mock WebSocket addEventListener for ${event}`);
+          // Store listeners if needed for more complex simulation, e.g., this['on'+event] = callback;
+        };
+        // Simulate open and close events if necessary for client logic, though likely not for this test
+        // setTimeout(() => { if (this.onopen) this.onopen(); }, 10); // Example: simulate open
+        // setTimeout(() => { if (this.onclose) this.onclose(); }, 20); // Example: simulate close
+      };
 
       // Force setTimeout to be faster, to avoid delays
       //   (add conditional logic here if we need to not do this later)
@@ -534,15 +552,39 @@ function loadAllClientScripts() {
 
       if (!window.fetch) {
         window.fetch = async function(url, options) {
-          // console.log(`MOCK FETCH CALLED: URL=${url}, Options=${JSON.stringify(options)}`); // Debug log
-          // Log the fetch call for debugging during tests if needed
-          // console.log(`Mock fetch called for URL: ${url}`, options);
+          console.log(`Mock fetch called for URL: ${url}`, options);
+          if (url === "/session") {
+            const body = options && options.body ? JSON.parse(options.body) : {};
+            if (body.path === "/topics") {
+              console.log("Mock fetch returning success for /topics");
+              return {
+                ok: true,
+                status: 200,
+                statusText: "OK",
+                json: async () => ({
+                  success: true,
+                  path: "/topics",
+                  topics: [], // Empty is fine for this test
+                  comments: [],
+                  activities: [],
+                  notifications: [],
+                  user: {}, // Basic user object
+                  tag: {},   // Basic tag object
+                  subscribed_to_users: 0,
+                  // Add any other essential fields that renderPage might expect
+                }),
+                text: async () => JSON.stringify({ success: true, path: "/topics", topics: [] /* ... */ })
+              };
+            }
+          }
+          // Default mock fetch for other URLs or unhandled session paths
+          console.log("Mock fetch returning default error");
           return {
             ok: false,
             status: 500,
             statusText: "Internal Server Error",
-            json: async () => ({ success: false, error: "Test error" }),
-            text: async () => JSON.stringify({ success: false, error: "Test error" })
+            json: async () => ({ success: false, error: "Test error: Unmocked fetch path" }),
+            text: async () => JSON.stringify({ success: false, error: "Test error: Unmocked fetch path" })
           };
         };
       }


### PR DESCRIPTION
This commit introduces new integration tests for your first interaction with the application: the welcome/terms page.

The following tests were added in `tests/client/integration/welcome.integration.test.js`:
- `testInitialPageShowsWelcomeOrTerms`: Verifies that the initial page correctly displays the "Terms and conditions" header and the "Join the Discussion" button.
- `testAgreeingToTermsNavigatesToNextPageAndSetsLocalStorage`: Tests the process of agreeing to the terms by clicking the "Join the Discussion" button. It asserts that:
    - The welcome header is removed.
    - The `localStorage` item indicating terms agreement (`<key>:agreed`) is set to "true".
    - The `localStorage` item for `last_root_path` is updated to "/topics".
    - The topics view (indicated by a `<topics>` wrapper element) is rendered.

During the implementation of these tests, `jsdom` was installed, and several improvements were made to the test helper environment (`tests/client/shared/testHelpers.js`), particularly for mocking `WebSocket` and `fetch` to better simulate the application's behavior within JSDOM.

Additionally, a minor fix was applied to `tests/client/integration/profilePicture.integration.test.js` to update an expected error message from the `fetch` mock, ensuring all integration tests pass.