### PR TITLE
feat: Add integration test for topic navigation

### DIFF
--- a/tests/client/integration/navigation.integration.test.js
+++ b/tests/client/integration/navigation.integration.test.js
@@ -1,0 +1,110 @@
+const path = require('path');
+const { loadAllClientScripts } = require('../shared/testHelpers.js');
+const { assertEquals, runTests } = require('../shared/testUtils.js');
+
+const tests = {
+    testNavigateToFirstTopicDetail: async () => {
+        const window = loadAllClientScripts();
+
+        // Initial check for window.state
+        assertEquals(true, !!window.state, "window.state should be defined after loadAllClientScripts.");
+        if (!window.state) return; // Guard against further errors if state is not defined
+
+        const { document, state } = window; // Destructure after checking window.state
+
+        assertEquals(true, typeof state.path === 'string', "state.path should be a string.");
+
+        // Check if a known SVG icon can be queried before renderTopic is called
+        const testIconSvg = window.$("icons icon[more] svg");
+        assertEquals(true, !!testIconSvg, "Test query for 'icons icon[more] svg' should find an element.");
+        if (testIconSvg) {
+            assertEquals("svg", testIconSvg.tagName?.toLowerCase(), "The found element should be an SVG tag.");
+        }
+
+
+        // 1. Agree to terms to navigate to /topics
+        const joinButton = document.querySelector('a[href="/topics"][big]');
+        assertEquals(true, !!joinButton, "Agree button should exist on the welcome page.");
+        if (!joinButton) return;
+        joinButton.click();
+
+        // Wait for navigation and rendering (increased delay for page load)
+        await new Promise(resolve => setTimeout(resolve, 200));
+
+        // Verify navigation to /topics
+        assertEquals("/topics", state.path, "Path should be /topics after agreeing to terms.");
+        const topicsWrapper = document.querySelector('topics'); // Element that wraps all topics
+        assertEquals(true, !!topicsWrapper, "Topics wrapper element should be present on /topics page.");
+
+        // Mock that topics have loaded (in a real scenario, startSession would fetch and render them)
+        // For this test, we'll assume renderTopics has been called and populated topics
+        // We need at least one topic to click on. Let's simulate a minimal topic structure.
+        // This is a simplification; ideally, test data would be served.
+        if (topicsWrapper && !topicsWrapper.querySelector('topic[trimmed]')) {
+            const mockTopicData = {
+                slug: "test-topic-1",
+                title: "Test Topic 1",
+                body: "Short body",
+                user_slug: "user1",
+                display_name: "User One",
+                tags: "politics", // Changed from "general" to an existing icon tag
+                profile_picture_uuid: null,
+                display_name_index: 0,
+                user_verified: false,
+                note: "",
+                poll_1: null,
+                favorited: false,
+                favorite_count: 0,
+                commented: false,
+                comment_count: 0,
+                image_uuids: null
+            };
+            // We need to load renderTopic to manually render one for the test to proceed
+            const renderTopic = window.renderTopic; // Assumes renderTopic is globally available after loadAllClientScripts
+            if (renderTopic) {
+                 const $mockTopic = renderTopic(mockTopicData);
+                 topicsWrapper.appendChild($mockTopic);
+            } else {
+                console.error("renderTopic function not found on window object. Skipping part of test.");
+                // Potentially fail the test here or make it inconclusive
+                assertEquals(true, false, "renderTopic function is required for this test and was not found.");
+                return;
+            }
+        }
+
+        // 2. Find and click the first topic link/element
+        const firstTopicElement = document.querySelector('topics > topic[trimmed]');
+        assertEquals(true, !!firstTopicElement, "First topic element with [trimmed] attribute should be found on the /topics page.");
+        if (!firstTopicElement) return;
+
+        // Simulate click on the topic element itself, which should trigger navigation
+        firstTopicElement.click();
+
+        // Wait for navigation and rendering
+        await new Promise(resolve => setTimeout(resolve, 200));
+
+        // 3. Assert navigation to the topic detail path
+        // The exact slug might be hard to predict if topics are dynamic,
+        // so check if path starts with /topic/ and is not /topics
+        assertEquals(true, state.path.startsWith('/topic/'), `Path should start with /topic/ after clicking a topic. Actual path: ${state.path}`);
+        assertEquals(false, state.path === '/topics', `Path should no longer be /topics. Actual path: ${state.path}`);
+
+        // To get the specific slug for a more precise check, we'd ideally get it from the mock data.
+        // For this example, we'll assume the first topic rendered was 'test-topic-1'
+        const expectedTopicPath = "/topic/test-topic-1";
+        assertEquals(expectedTopicPath, state.path, `Path should be '${expectedTopicPath}' after clicking the first topic.`);
+
+        // 4. Assert that topic detail specific elements are rendered
+        // Check for the <comments> wrapper, indicating comments can be loaded/displayed
+        const commentsWrapper = document.querySelector('main-content-wrapper[active] comments');
+        assertEquals(true, !!commentsWrapper, "Comments wrapper element should be present on the topic detail page.");
+
+        // Check that the main topic display is no longer 'trimmed' (if it was the same element being re-rendered)
+        // Or, more simply, check if a full topic body indicative element exists.
+        // renderTopic uses markdownToElements. Let's assume a <p> tag will be part of the body.
+        const topicBodyIndicator = document.querySelector('main-content-wrapper[active] topic p');
+        assertEquals(true, !!topicBodyIndicator, "A <p> tag (indicator of topic body) should be present in the main content of the topic detail page.");
+    }
+};
+
+runTests(path.basename(__filename), Object.values(tests));

--- a/tests/client/shared/testHelpers.js
+++ b/tests/client/shared/testHelpers.js
@@ -479,27 +479,81 @@ function loadAllClientScripts() {
 
   // Parse the includes
   const parseIncludes = (fromHtmlContent) => {
-    let returningHtmlContent = fromHtmlContent
-    const scriptLineRegex = /(.*<!--#include\s+file="[^"]+\.[^"]+".*)/g;
-    const scriptRegex = /[^"]+\.[^"]+/;
+    let returningHtmlContent = fromHtmlContent;
+    // Regex to find <!--#include file="..." --> directives
+    const includeDirectiveRegex = /<!--#include\s+file="([^"]+)"\s*-->/g;
     let match;
-    while ((match = scriptLineRegex.exec(fromHtmlContent)) !== null) {
+
+    // Keep replacing until no more include directives are found
+    // This handles nested includes by repeatedly applying the regex
+    while ((match = includeDirectiveRegex.exec(returningHtmlContent)) !== null) {
+      const directive = match[0]; // The full directive, e.g., <!--#include file="path/to/file.html" -->
+      const relativeFilePath = match[1]; // The path from the directive, e.g., "path/to/file.html"
+
       // Resolve the script path relative to the directory of the indexHtmlFile
-      const indexDir = path.dirname(indexPath)
-      const fullLine = match[0]
-      const filePath = fullLine.match(scriptRegex)[0]
-      // console.warn(match.index, fullLine.length, filePath)
-      // console.warn(fullLine, filePath) 
-      const scriptContent = fs.readFileSync(indexDir + "/" + filePath, "utf8")
-      returningHtmlContent = returningHtmlContent.replace(fullLine, scriptContent)
+      const indexDir = path.dirname(indexPath);
+      const absoluteFilePath = path.resolve(indexDir, relativeFilePath); // Use path.resolve for robustness
+
+      try {
+        const fileContent = fs.readFileSync(absoluteFilePath, "utf8");
+        returningHtmlContent = returningHtmlContent.replace(directive, fileContent);
+      } catch (error) {
+        console.error(`Error including file "${absoluteFilePath}": ${error.message}`);
+        // Optionally, replace with an error message or leave the directive,
+        // depending on desired error handling. For now, it will effectively remove the directive if file not found.
+        // returningHtmlContent = returningHtmlContent.replace(directive, `<!-- Error including ${relativeFilePath} -->`);
+      }
     }
-    return returningHtmlContent
-  }
-  // Parse the initial includes
-  const firstPassHtmlContent = parseIncludes(indexHtmlContent)
-  // Parse the includes of includes
-  const finalIndexHtmlContent = parseIncludes(firstPassHtmlContent)
+    return returningHtmlContent;
+  };
+
+  // Pre-process HTML to uncomment JS includes
+  // Removes leading "// " from lines containing "<!--#include file="client/...js" -->"
+  let processedIndexHtmlContent = indexHtmlContent.split('\n').map(line => {
+    if (line.trim().startsWith('//') && line.includes('<!--#include') && line.includes('.js"')) {
+      return line.replace('//', '');
+    }
+    return line;
+  }).join('\n');
+
+  // Parse includes. Iterative to handle nested includes.
+  let finalIndexHtmlContent = processedIndexHtmlContent;
+  let previousHtmlContent;
+  do {
+    previousHtmlContent = finalIndexHtmlContent;
+    finalIndexHtmlContent = parseIncludes(finalIndexHtmlContent);
+  } while (finalIndexHtmlContent !== previousHtmlContent);
   // console.warn("Final HTML content loaded into JSDOM:", finalIndexHtmlContent) // DEBUGGING: Log the final HTML
+
+  // Attempt to ensure 'state' is explicitly assigned to 'window.state'
+  // This is a workaround for potential JSDOM issues with 'const state' in global scope
+  finalIndexHtmlContent = finalIndexHtmlContent.replace(
+    /const state = {/,
+    "window.state = {"
+  );
+  if (!finalIndexHtmlContent.includes("window.state = {")) {
+    console.warn("WARNING: Failed to replace 'const state = {' with 'window.state = {' in HTML content. State might still be undefined.");
+  }
+
+  // Attempt to ensure 'renderTopic' is explicitly assigned to 'window.renderTopic'
+  finalIndexHtmlContent = finalIndexHtmlContent.replace(
+    /const renderTopic = \(/,
+    "window.renderTopic = ("
+  );
+  if (!finalIndexHtmlContent.includes("window.renderTopic = (")) {
+    console.warn("WARNING: Failed to replace 'const renderTopic = (' with 'window.renderTopic = (' in HTML content. renderTopic might still be undefined.");
+  }
+
+  // Attempt to ensure 'flint' ($) is explicitly assigned to 'window.$'
+  // Note the more specific regex to avoid unintended replacements if $ is used elsewhere.
+  finalIndexHtmlContent = finalIndexHtmlContent.replace(
+    /const \$ = \((selector_or_flint, flint_args_or_element)\) => {/,
+    "window.$ = (selector_or_flint, flint_args_or_element) => {"
+  );
+  if (!finalIndexHtmlContent.includes("window.$ = (selector_or_flint, flint_args_or_element) => {")) {
+    console.warn("WARNING: Failed to replace 'const $ = (...)' with 'window.$ = (...)' in HTML content. Flint $ might still be undefined or incorrect.");
+  }
+
   const virtualConsole = new VirtualConsole()
   virtualConsole.sendTo(console)
   const dom = new JSDOM(finalIndexHtmlContent, {
@@ -563,21 +617,69 @@ function loadAllClientScripts() {
                 json: async () => ({
                   success: true,
                   path: "/topics",
-                  topics: [], // Empty is fine for this test
+                  topics: [],
                   comments: [],
                   activities: [],
                   notifications: [],
-                  user: {}, // Basic user object
-                  tag: {},   // Basic tag object
+                  user: {},
+                  tag: {},
                   subscribed_to_users: 0,
-                  // Add any other essential fields that renderPage might expect
                 }),
-                text: async () => JSON.stringify({ success: true, path: "/topics", topics: [] /* ... */ })
+                text: async () => JSON.stringify({ success: true, path: "/topics", topics: [], comments: [], activities: [], notifications: [], user: {}, tag: {}, subscribed_to_users: 0 })
+              };
+            } else if (body.path && body.path.startsWith("/topic/")) {
+              // Handle fetch for a specific topic detail page
+              // For the test, we'll use a simplified version of mockTopicData
+              // In a real scenario, this would be the detailed topic data
+              const slug = body.path.split("/")[2];
+              // This is a very basic mock. A real app might fetch more detailed data.
+              // We'll assume the slug 'test-topic-1' is the one being tested.
+              // If other slugs are needed, this mock would need to be more sophisticated
+              // or the test data aligned.
+              const mockDetailTopic = {
+                slug: slug,
+                title: `Test Topic ${slug}`,
+                body: "Full body of the test topic. This should be longer than the summary.",
+                user_slug: "user1",
+                display_name: "User One",
+                tags: "politics", // Keep consistent with list view for now
+                profile_picture_uuid: null,
+                display_name_index: 0,
+                user_verified: false,
+                note: "",
+                poll_1: null,
+                favorited: false,
+                favorite_count: 0,
+                commented: false,
+                comment_count: 0, // For topic detail, comments are separate
+                image_uuids: null,
+                // Fields that might appear in a detail view but not summary
+                topic_id: 123, // Example ID
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+              };
+
+              return {
+                ok: true,
+                status: 200,
+                statusText: "OK",
+                json: async () => ({
+                  success: true,
+                  path: body.path,
+                  topics: [mockDetailTopic], // Send back the specific topic in a 'topics' array
+                  comments: [], // Start with empty comments for simplicity
+                  activities: [],
+                  notifications: [],
+                  user: {},
+                  tag: {},
+                  subscribed_to_users: 0,
+                }),
+                text: async () => JSON.stringify({ success: true, path: body.path, topics: [mockDetailTopic], comments: [], activities: [], notifications: [], user: {}, tag: {}, subscribed_to_users: 0 })
               };
             }
           }
           // Default mock fetch for other URLs or unhandled session paths
-          // console.log("Mock fetch returning default error");
+          // console.warn(`Mock fetch unhandled URL: ${url} or body.path: ${body?.path}`);
           return {
             ok: false,
             status: 500,


### PR DESCRIPTION
Adds a new integration test case in `tests/client/integration/navigation.integration.test.js` that verifies your flow from the welcome screen to the topics list, and then successfully navigates to a topic's detail page.

This commit also includes several improvements to the test environment:

- Updated `tests/client/shared/testHelpers.js`:
    - Ensured global constants (like state, renderTopic, $) from client scripts are reliably attached to the mock `window` object.
    - Corrected the `parseIncludes` function to properly handle Server-Side Includes (SSI) for SVG files, preventing `cloneNode` errors.
    - Added a pre-processing step to uncomment JavaScript include lines in `index.html` content before parsing, fixing issues with client scripts being commented out.
    - Adjusted the mock `fetch` response for single topic detail pages to provide `data.topics` as an array, aligning with expectations in `renderTopics.js`.

- Modified mock data in the new navigation test to use an existing tag ("politics") to prevent errors related to missing SVG icons in `renderTopic.js`.

These changes make the client-side integration testing more robust and ensure the new navigation path is covered.