### PR TITLE
feat: Add integration test for topics list display

### DIFF
--- a/tests/client/integration/topics_list_display.integration.test.js
+++ b/tests/client/integration/topics_list_display.integration.test.js
@@ -1,0 +1,98 @@
+const path = require('path');
+const { setupIntegrationTestEnvironment } = require('./../shared/integrationTestSetup.js');
+const { assertEquals, runTests } = require('../shared/testUtils.js');
+
+const testTopicsListDisplaysFetchedTopics = async () => {
+    const { window } = await setupIntegrationTestEnvironment();
+    const { document, state } = window;
+
+    const originalFetch = window.fetch;
+    let fetchCalledWithTopicsPath = false;
+
+    window.fetch = async (url, options) => {
+        if (url === '/session' && options && options.body) {
+            try {
+                const body = JSON.parse(options.body);
+                if (body.path === '/topics') {
+                    fetchCalledWithTopicsPath = true;
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            success: true,
+                            path: "/topics",
+                            topics: [
+                                { "slug": "tech-trends", "title": "Tech Trends 2024", "body": "Exploring upcoming tech.\n\nThis is the first topic.", "user_slug": "jdoe", "display_name": "John Doe", "tags": "work", "comment_count": 5, "favorite_count": 10, "favorited": false, "commented": false, "image_uuids": null, "profile_picture_uuid": null, "display_name_index": 0, "user_verified": false, "note": "", "poll_1": null },
+                                { "slug": "science-discoveries", "title": "Science Discoveries", "body": "Latest in science.\n\nThis is the second topic.", "user_slug": "jane", "display_name": "Jane Roe", "tags": "science", "comment_count": 3, "favorite_count": 7, "favorited": true, "commented": false, "image_uuids": null, "profile_picture_uuid": null, "display_name_index": 0, "user_verified": true, "note": "", "poll_1": null }
+                            ],
+                            comments: [],
+                            activities: [],
+                            notifications: [],
+                            user: {},
+                            tag: {},
+                            subscribed_to_users: 0
+                        })
+                    });
+                }
+            } catch (e) {
+                // Not a JSON body or other parsing error, fall through to original fetch
+            }
+        }
+        return originalFetch(url, options);
+    };
+
+    try {
+        // Simulate agreeing to terms to navigate to /topics
+        const joinButton = document.querySelector('a[href="/topics"][big]');
+        assertEquals(joinButton !== null, true, 'Join the Discussion button should exist');
+        if (joinButton) {
+            joinButton.click();
+        }
+
+        // Wait for navigation and rendering
+        await new Promise(resolve => setTimeout(resolve, 200)); // Adjusted timeout for potential async operations
+
+        assertEquals(state.path, '/topics', 'State path should be /topics after navigation');
+        assertEquals(fetchCalledWithTopicsPath, true, 'window.fetch should have been called with path /topics');
+
+        const topicsWrapper = document.querySelector('topics');
+        assertEquals(topicsWrapper !== null, true, '<topics> wrapper element should be present');
+
+        if (topicsWrapper) {
+            const renderedTopicElements = topicsWrapper.querySelectorAll('topic');
+            assertEquals(renderedTopicElements.length, 2, 'Should render 2 topic elements based on mock data');
+
+            // Assert content of the first topic
+            const firstTopic = renderedTopicElements[0];
+            if (firstTopic) {
+                const firstTitle = firstTopic.querySelector('h2');
+                assertEquals(firstTitle && firstTitle.textContent.trim(), 'Tech Trends 2024', 'First topic title mismatch');
+                const firstBodySpan = firstTopic.querySelector('p > span'); // Target the span inside the first p
+                assertEquals(firstBodySpan !== null, true, 'First topic body span should exist');
+            } else {
+                throw new Error("First topic element not found for assertion.");
+            }
+
+            // Assert content of the second topic
+            const secondTopic = renderedTopicElements[1];
+            if (secondTopic) {
+                const secondTitle = secondTopic.querySelector('h2');
+                assertEquals(secondTitle && secondTitle.textContent.trim(), 'Science Discoveries', 'Second topic title mismatch');
+                const secondBodySpan = secondTopic.querySelector('p > span'); // Target the span inside the first p
+                assertEquals(secondBodySpan !== null, true, 'Second topic body span should exist');
+            } else {
+                throw new Error("Second topic element not found for assertion.");
+            }
+        }
+
+    } finally {
+        window.fetch = originalFetch; // Restore original fetch
+    }
+};
+
+const tests = {
+    testTopicsListDisplaysFetchedTopics
+    // Add other tests here if any in the future
+};
+
+runTests(path.basename(__filename), Object.values(tests));


### PR DESCRIPTION
Adds a new integration test case in `tests/client/integration/topics_list_display.integration.test.js`.

This test, `testTopicsListDisplaysFetchedTopics`, verifies the following:
- After navigating to the /topics page, topics fetched from the server are correctly rendered.
- It mocks the fetch call to /session for the /topics path to return a predefined set of topic data.
- It asserts that the correct number of topic elements are displayed.
- It asserts that the titles of the rendered topics match the mock data.
- It asserts that the body of the rendered topics is processed into the expected HTML structure (p > span) by markdownToElements.

The implementation of this test also involved:
- Ensuring `jsdom` is listed as a dev dependency.
- Adjusting mock data within the test to use valid icon tags to prevent rendering errors.
- Using `textContent` for more reliable DOM text assertions in JSDOM.